### PR TITLE
Add control-variant support and richer per-inverter telemetry

### DIFF
--- a/custom_components/bytewatt/__init__.py
+++ b/custom_components/bytewatt/__init__.py
@@ -1,6 +1,7 @@
 """The Byte-Watt integration."""
 import asyncio
 import logging
+import json
 
 import voluptuous as vol
 
@@ -8,6 +9,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.const import CONF_SCAN_INTERVAL
 import homeassistant.helpers.config_validation as cv
+from homeassistant.util import dt as dt_util
 
 from .bytewatt_client import ByteWattClient
 from .coordinator import ByteWattDataUpdateCoordinator
@@ -16,6 +18,8 @@ from .const import (
     CONF_USERNAME,
     CONF_PASSWORD,
     CONF_SCAN_INTERVAL,
+    CONF_CONTROL_VARIANT,
+    CONF_CONTROL_TARGET_SYSTEM_ID,
     CONF_RECOVERY_ENABLED,
     CONF_HEARTBEAT_INTERVAL,
     CONF_MAX_DATA_AGE,
@@ -24,6 +28,8 @@ from .const import (
     CONF_DIAGNOSTICS_MODE,
     CONF_AUTO_RECONNECT_TIME,
     DEFAULT_SCAN_INTERVAL,
+    DEFAULT_CONTROL_VARIANT,
+    DEFAULT_CONTROL_TARGET_SYSTEM_ID,
     DEFAULT_RECOVERY_ENABLED,
     DEFAULT_HEARTBEAT_INTERVAL,
     DEFAULT_MAX_DATA_AGE,
@@ -38,9 +44,13 @@ from .const import (
     SERVICE_SET_MINIMUM_SOC,
     SERVICE_SET_CHARGE_CAP,
     SERVICE_UPDATE_BATTERY_SETTINGS,
+    SERVICE_UPDATE_CYCLE_STRATEGY,
+    SERVICE_SET_CYCLE_DAY_SCHEDULE,
     SERVICE_FORCE_RECONNECT,
     SERVICE_HEALTH_CHECK,
     SERVICE_TOGGLE_DIAGNOSTICS,
+    SERVICE_FORCE_CHARGE,
+    SERVICE_STOP_FORCE_CHARGE,
     ATTR_END_DISCHARGE,
     ATTR_START_DISCHARGE,
     ATTR_START_CHARGE,
@@ -68,9 +78,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     # Get all configuration options with defaults
     options = entry.options or {}
     scan_interval = options.get(CONF_SCAN_INTERVAL, entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL))
+    control_variant = options.get(CONF_CONTROL_VARIANT, entry.data.get(CONF_CONTROL_VARIANT, DEFAULT_CONTROL_VARIANT))
+    control_target_system_id = options.get(
+        CONF_CONTROL_TARGET_SYSTEM_ID,
+        entry.data.get(CONF_CONTROL_TARGET_SYSTEM_ID, DEFAULT_CONTROL_TARGET_SYSTEM_ID),
+    )
     
     # Recovery options (can be added to config flow for future customization)
     recovery_options = {
+        CONF_CONTROL_VARIANT: control_variant,
+        CONF_CONTROL_TARGET_SYSTEM_ID: control_target_system_id,
         CONF_RECOVERY_ENABLED: options.get(CONF_RECOVERY_ENABLED, DEFAULT_RECOVERY_ENABLED),
         CONF_HEARTBEAT_INTERVAL: options.get(CONF_HEARTBEAT_INTERVAL, DEFAULT_HEARTBEAT_INTERVAL),
         CONF_MAX_DATA_AGE: options.get(CONF_MAX_DATA_AGE, DEFAULT_MAX_DATA_AGE),
@@ -255,6 +272,191 @@ async def register_battery_services(hass: HomeAssistant, client: ByteWattClient,
                 _LOGGER.error(f"Could not create diagnostics notification: {e}")
         else:
             _LOGGER.error("No ByteWatt integrations found to toggle diagnostics")
+
+    def _get_primary_coordinator():
+        for entry in hass.config_entries.async_entries(DOMAIN):
+            entry_data = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+            if entry_data and entry_data.get("coordinator"):
+                return entry_data["coordinator"]
+        return None
+
+    def _store_force_charge_diagnostics(coordinator, action: str, limit: int | None, results: dict):
+        diagnostics = {
+            "last_force_charge_action": action,
+            "last_force_charge_requested_limit": limit,
+            "last_force_charge_results": results,
+            "last_force_charge_updated_at": dt_util.now().isoformat(),
+        }
+        control_data = dict((coordinator.data or {}).get("control_variant", {}))
+        control_data.update(diagnostics)
+        coordinator._last_force_charge_diagnostics = diagnostics
+        coordinator._control_variant_info = control_data
+        if coordinator.data is not None:
+            coordinator.data["control_variant"] = control_data
+
+    def _resolve_force_charge_targets(call: ServiceCall, coordinator) -> list[dict]:
+        control_data = (coordinator.data or {}).get("control_variant", {})
+        inverters_data = (coordinator.data or {}).get("inverters", {})
+        candidate_map = {
+            candidate.get("system_id"): candidate
+            for candidate in (control_data.get("system_candidates") or [])
+            if candidate.get("system_id")
+        }
+        requested_system_id = call.data.get("system_id")
+        requested_sys_sn = call.data.get("sys_sn")
+        requested_charge_power = call.data.get("charge_power")
+
+        if requested_system_id:
+            candidate = candidate_map.get(requested_system_id, {})
+            resolved_sys_sn = requested_sys_sn or candidate.get("sys_sn")
+            current_soc = None
+            if resolved_sys_sn:
+                current_soc = (inverters_data.get(resolved_sys_sn) or {}).get("soc")
+            return [{
+                "system_id": requested_system_id,
+                "sys_sn": resolved_sys_sn,
+                "charge_power": requested_charge_power,
+                "current_soc": current_soc,
+            }]
+
+        raw_targets = control_data.get("system_candidates") or []
+        targets = []
+        seen_system_ids = set()
+        for candidate in raw_targets:
+            system_id = candidate.get("system_id")
+            if not system_id or system_id in seen_system_ids:
+                continue
+            seen_system_ids.add(system_id)
+            try:
+                default_power = int(float(candidate.get("poinv") or 5000))
+            except (TypeError, ValueError):
+                default_power = 5000
+            targets.append({
+                "system_id": system_id,
+                "sys_sn": candidate.get("sys_sn"),
+                "charge_power": requested_charge_power if requested_charge_power is not None else default_power,
+                "current_soc": (inverters_data.get(candidate.get("sys_sn")) or {}).get("soc"),
+            })
+
+        if targets:
+            return targets
+
+        fallback_system_id = (
+            control_data.get("control_system_id")
+            or control_data.get("target_system_id")
+            or control_data.get("system_id")
+        )
+        if not fallback_system_id:
+            return []
+        return [{
+            "system_id": fallback_system_id,
+            "sys_sn": requested_sys_sn,
+            "charge_power": requested_charge_power,
+            "current_soc": (inverters_data.get(requested_sys_sn) or {}).get("soc") if requested_sys_sn else None,
+        }]
+
+    async def handle_force_charge(call: ServiceCall):
+        """Handle force-charge control for one or more ByteWatt systems."""
+        coordinator = _get_primary_coordinator()
+        if not coordinator:
+            _LOGGER.error("No ByteWatt integration found")
+            return False
+
+        targets = _resolve_force_charge_targets(call, coordinator)
+        if not targets:
+            _LOGGER.error("No ByteWatt systems available for force charge")
+            return False
+
+        limit = int(call.data.get("limit", 95))
+        results = {}
+        all_ok = True
+        attempted = False
+
+        for target in targets:
+            system_id = target["system_id"]
+            current_soc = target.get("current_soc")
+            if current_soc is not None and float(current_soc) >= limit:
+                results[system_id] = {
+                    "sys_sn": target.get("sys_sn"),
+                    "charge_power": target.get("charge_power"),
+                    "current_soc": current_soc,
+                    "skipped": True,
+                    "skip_reason": "soc_at_or_above_limit",
+                    "api_ok": True,
+                }
+                continue
+
+            attempted = True
+            ok = await coordinator.client.force_charge(
+                system_id=system_id,
+                sys_sn=target.get("sys_sn"),
+                limit=limit,
+                charge_power=target.get("charge_power"),
+            )
+            results[system_id] = {
+                "sys_sn": target.get("sys_sn"),
+                "charge_power": target.get("charge_power"),
+                "current_soc": current_soc,
+                "api_ok": ok,
+            }
+            all_ok = all_ok and ok
+
+        await asyncio.sleep(2)
+        for system_id, result in results.items():
+            result["status"] = await coordinator.client.get_force_charge_status(system_id)
+            result["limit"] = await coordinator.client.get_force_charge_limit(system_id)
+
+        verified_ok = True
+        for result in results.values():
+            if result.get("skipped"):
+                continue
+            applied_limit = result.get("limit")
+            limit_matches = applied_limit is not None and abs(float(applied_limit) - limit) < 0.01
+            if not (result.get("api_ok") and (result.get("status") is True or limit_matches)):
+                verified_ok = False
+                break
+
+        if not attempted:
+            _LOGGER.warning("Force charge skipped for all targets because SOC is already at or above %s%%", limit)
+        _store_force_charge_diagnostics(coordinator, "force_charge", limit, results)
+        _LOGGER.info("Force charge results: %s", results)
+        await coordinator.async_request_refresh()
+        return all_ok and verified_ok
+
+    async def handle_stop_force_charge(call: ServiceCall):
+        """Handle stopping force charge for one or more ByteWatt systems."""
+        coordinator = _get_primary_coordinator()
+        if not coordinator:
+            _LOGGER.error("No ByteWatt integration found")
+            return False
+
+        targets = _resolve_force_charge_targets(call, coordinator)
+        if not targets:
+            _LOGGER.error("No ByteWatt systems available to stop force charge")
+            return False
+
+        results = {}
+        all_ok = True
+        for target in targets:
+            system_id = target["system_id"]
+            ok = await coordinator.client.stop_force_charge(system_id=system_id)
+            results[system_id] = {"api_ok": ok}
+            all_ok = all_ok and ok
+
+        await asyncio.sleep(2)
+        for system_id, result in results.items():
+            result["status"] = await coordinator.client.get_force_charge_status(system_id)
+            result["limit"] = await coordinator.client.get_force_charge_limit(system_id)
+
+        verified_ok = all(
+            result["api_ok"] and result.get("status") is False
+            for result in results.values()
+            if result.get("status") is not None
+        )
+        _store_force_charge_diagnostics(coordinator, "stop_force_charge", None, results)
+        _LOGGER.info("Stop force charge results: %s", results)
+        await coordinator.async_request_refresh()
+        return all_ok and verified_ok
     
     # Legacy service - set discharge end time only
     async def handle_set_discharge_time(call: ServiceCall):
@@ -442,13 +644,24 @@ async def register_battery_services(hass: HomeAssistant, client: ByteWattClient,
         discharge_end_time = call.data.get(ATTR_END_DISCHARGE)
         charge_start_time = call.data.get(ATTR_START_CHARGE)
         charge_end_time = call.data.get(ATTR_END_CHARGE)
+        charge_start_time_2 = call.data.get("start_charge_2")
+        charge_end_time_2 = call.data.get("end_charge_2")
+        discharge_start_time_2 = call.data.get("start_discharge_2")
+        discharge_end_time_2 = call.data.get("end_discharge_2")
         minimum_soc = call.data.get(ATTR_MINIMUM_SOC)
         charge_cap = call.data.get(ATTR_CHARGE_CAP)
+        ups_reserve = call.data.get("ups_reserve")
+        charge_mode_setting = call.data.get("charge_mode_setting")
+        export_limit_w1 = call.data.get("export_limit_w1")
+        export_limit_w2 = call.data.get("export_limit_w2")
         
         # Check if at least one parameter is provided
         if (discharge_start_time is None and discharge_end_time is None and
                 charge_start_time is None and charge_end_time is None and
-                minimum_soc is None and charge_cap is None):
+                charge_start_time_2 is None and charge_end_time_2 is None and
+                discharge_start_time_2 is None and discharge_end_time_2 is None and
+                minimum_soc is None and charge_cap is None and ups_reserve is None and
+                charge_mode_setting is None and export_limit_w1 is None and export_limit_w2 is None):
             _LOGGER.error("No battery settings provided to update")
             return
 
@@ -461,6 +674,16 @@ async def register_battery_services(hass: HomeAssistant, client: ByteWattClient,
         if not coordinator:
             _LOGGER.error("No ByteWatt integration found")
             return False
+
+        control_data = (coordinator.data or {}).get("control_variant", {})
+        effective_variant = control_data.get("effective_variant")
+        if effective_variant and effective_variant != "charge_config":
+            _LOGGER.error(
+                "Refusing legacy update_battery_settings write while control variant is '%s'; "
+                "system appears to be using cycle-strategy controls",
+                effective_variant,
+            )
+            return False
         
         # Update battery settings
         success = await coordinator.client.update_battery_settings(
@@ -468,8 +691,16 @@ async def register_battery_services(hass: HomeAssistant, client: ByteWattClient,
             discharge_end_time=discharge_end_time,
             charge_start_time=charge_start_time,
             charge_end_time=charge_end_time,
+            charge_start_time_2=charge_start_time_2,
+            charge_end_time_2=charge_end_time_2,
+            discharge_start_time_2=discharge_start_time_2,
+            discharge_end_time_2=discharge_end_time_2,
             minimum_soc=minimum_soc,
-            charge_cap=charge_cap
+            charge_cap=charge_cap,
+            ups_reserve=ups_reserve,
+            charge_mode_setting=charge_mode_setting,
+            export_limit_w1=export_limit_w1,
+            export_limit_w2=export_limit_w2,
         )
         
         if success:
@@ -477,6 +708,136 @@ async def register_battery_services(hass: HomeAssistant, client: ByteWattClient,
         else:
             _LOGGER.error("Failed to update battery settings")
         
+        return success
+
+    async def handle_update_cycle_strategy(call: ServiceCall):
+        """Handle cycle-strategy based discharge control updates."""
+        charge_start_time = call.data.get(ATTR_START_CHARGE)
+        charge_end_time = call.data.get(ATTR_END_CHARGE)
+        charge_cap = call.data.get(ATTR_CHARGE_CAP)
+        charge_power = call.data.get("charge_power")
+        charge_enabled = call.data.get("charge_enabled")
+        discharge_start_time = call.data.get(ATTR_START_DISCHARGE)
+        discharge_end_time = call.data.get(ATTR_END_DISCHARGE)
+        minimum_soc = call.data.get(ATTR_MINIMUM_SOC)
+        discharge_power = call.data.get("discharge_power")
+        discharge_enabled = call.data.get("discharge_enabled")
+
+        coordinator = None
+        for entry in hass.config_entries.async_entries(DOMAIN):
+            coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+            break
+
+        if not coordinator:
+            _LOGGER.error("No ByteWatt integration found")
+            return False
+
+        control_data = (coordinator.data or {}).get("control_variant", {})
+        system_id = control_data.get("system_id")
+        target_system_id = call.data.get("system_id") or control_data.get("target_system_id") or system_id
+        effective_variant = control_data.get("effective_variant")
+
+        if effective_variant != "cycle_strategy":
+            _LOGGER.error(
+                "Refusing cycle strategy update because active control variant is '%s'",
+                effective_variant,
+            )
+            return False
+
+        if not target_system_id:
+            _LOGGER.error("No cycle-strategy system_id detected")
+            return False
+
+        success = await coordinator.client.update_cycle_strategy(
+            system_id=target_system_id,
+            charge_start_time=charge_start_time,
+            charge_end_time=charge_end_time,
+            charge_cap=charge_cap,
+            charge_power=charge_power,
+            charge_enabled=charge_enabled,
+            discharge_start_time=discharge_start_time,
+            discharge_end_time=discharge_end_time,
+            minimum_soc=minimum_soc,
+            discharge_power=discharge_power,
+            discharge_enabled=discharge_enabled,
+        )
+
+        if success:
+            _LOGGER.info("Successfully updated cycle strategy")
+            await coordinator.async_request_refresh()
+        else:
+            _LOGGER.error("Failed to update cycle strategy")
+
+        return success
+
+    async def handle_set_cycle_day_schedule(call: ServiceCall):
+        """Handle full day cycle schedule updates for cycle-strategy systems."""
+        coordinator = None
+        for entry in hass.config_entries.async_entries(DOMAIN):
+            coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+            break
+
+        if not coordinator:
+            _LOGGER.error("No ByteWatt integration found")
+            return False
+
+        control_data = (coordinator.data or {}).get("control_variant", {})
+        system_id = control_data.get("system_id")
+        target_system_id = call.data.get("system_id") or control_data.get("target_system_id") or system_id
+        effective_variant = control_data.get("effective_variant")
+
+        if effective_variant != "cycle_strategy":
+            _LOGGER.error(
+                "Refusing cycle day schedule update because active control variant is '%s'",
+                effective_variant,
+            )
+            return False
+
+        if not target_system_id:
+            _LOGGER.error("No cycle-strategy system_id detected")
+            return False
+
+        charge_windows = call.data.get("charge_windows")
+        discharge_windows = call.data.get("discharge_windows")
+        minimum_soc = call.data.get(ATTR_MINIMUM_SOC)
+        charge_cap = call.data.get(ATTR_CHARGE_CAP)
+        charge_power = call.data.get("charge_power")
+        discharge_power = call.data.get("discharge_power")
+
+        if isinstance(charge_windows, str):
+            charge_windows = json.loads(charge_windows)
+        if isinstance(discharge_windows, str):
+            discharge_windows = json.loads(discharge_windows)
+
+        _LOGGER.info(
+            "Requested cycle day schedule update for %s with %s charge windows and %s discharge windows",
+            target_system_id,
+            len(charge_windows or []),
+            len(discharge_windows or []),
+        )
+
+        success = await coordinator.client.update_cycle_strategy(
+            system_id=target_system_id,
+            charge_windows=charge_windows,
+            discharge_windows=discharge_windows,
+            charge_cap=charge_cap,
+            minimum_soc=minimum_soc,
+            charge_power=charge_power,
+            discharge_power=discharge_power,
+            charge_enabled=bool(charge_windows),
+            discharge_enabled=bool(discharge_windows),
+        )
+
+        if success:
+            _LOGGER.info(
+                "Successfully updated cycle day schedule (%s charge windows, %s discharge windows)",
+                len(charge_windows or []),
+                len(discharge_windows or []),
+            )
+            await coordinator.async_request_refresh()
+        else:
+            _LOGGER.error("Failed to update cycle day schedule")
+
         return success
 
     # Register all services
@@ -544,6 +905,71 @@ async def register_battery_services(hass: HomeAssistant, client: ByteWattClient,
             vol.Optional(ATTR_START_CHARGE): cv.string,
             vol.Optional(ATTR_END_CHARGE): cv.string,
             vol.Optional(ATTR_MINIMUM_SOC): vol.All(vol.Coerce(int), vol.Range(min=1, max=100)),
+            vol.Optional(ATTR_CHARGE_CAP): vol.All(vol.Coerce(int), vol.Range(min=1, max=100)),
+            vol.Optional("start_charge_2"): cv.string,
+            vol.Optional("end_charge_2"): cv.string,
+            vol.Optional("start_discharge_2"): cv.string,
+            vol.Optional("end_discharge_2"): cv.string,
+            vol.Optional("ups_reserve"): vol.All(vol.Coerce(int), vol.Range(min=0, max=100)),
+            vol.Optional("charge_mode_setting"): vol.All(vol.Coerce(int), vol.Range(min=0, max=10)),
+            vol.Optional("export_limit_w1"): vol.All(vol.Coerce(int), vol.Range(min=0, max=50000)),
+            vol.Optional("export_limit_w2"): vol.All(vol.Coerce(int), vol.Range(min=0, max=50000)),
+        })
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_UPDATE_CYCLE_STRATEGY,
+        handle_update_cycle_strategy,
+        schema=vol.Schema({
+            vol.Optional(ATTR_START_CHARGE): cv.string,
+            vol.Optional(ATTR_END_CHARGE): cv.string,
+            vol.Optional(ATTR_CHARGE_CAP): vol.All(vol.Coerce(int), vol.Range(min=1, max=100)),
+            vol.Optional("charge_power"): vol.All(vol.Coerce(int), vol.Range(min=0, max=50000)),
+            vol.Optional("charge_enabled"): cv.boolean,
+            vol.Optional(ATTR_START_DISCHARGE): cv.string,
+            vol.Optional(ATTR_END_DISCHARGE): cv.string,
+            vol.Optional(ATTR_MINIMUM_SOC): vol.All(vol.Coerce(int), vol.Range(min=1, max=100)),
+            vol.Optional("discharge_power"): vol.All(vol.Coerce(int), vol.Range(min=0, max=50000)),
+            vol.Optional("discharge_enabled"): cv.boolean,
+            vol.Optional("system_id"): cv.string,
+        })
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_CYCLE_DAY_SCHEDULE,
+        handle_set_cycle_day_schedule,
+        schema=vol.Schema({
+            vol.Optional("charge_windows"): vol.Any(cv.string, list),
+            vol.Optional("discharge_windows"): vol.Any(cv.string, list),
+            vol.Optional(ATTR_MINIMUM_SOC): vol.All(vol.Coerce(int), vol.Range(min=1, max=100)),
+            vol.Optional(ATTR_CHARGE_CAP): vol.All(vol.Coerce(int), vol.Range(min=1, max=100)),
+            vol.Optional("charge_power"): vol.All(vol.Coerce(int), vol.Range(min=0, max=50000)),
+            vol.Optional("discharge_power"): vol.All(vol.Coerce(int), vol.Range(min=0, max=50000)),
+            vol.Optional("system_id"): cv.string,
+        })
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_FORCE_CHARGE,
+        handle_force_charge,
+        schema=vol.Schema({
+            vol.Optional("limit", default=95): vol.All(vol.Coerce(int), vol.Range(min=1, max=100)),
+            vol.Optional("charge_power"): vol.All(vol.Coerce(int), vol.Range(min=0, max=50000)),
+            vol.Optional("system_id"): cv.string,
+            vol.Optional("sys_sn"): cv.string,
+        })
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_STOP_FORCE_CHARGE,
+        handle_stop_force_charge,
+        schema=vol.Schema({
+            vol.Optional("system_id"): cv.string,
+            vol.Optional("sys_sn"): cv.string,
         })
     )
     

--- a/custom_components/bytewatt/api/neovolt_client.py
+++ b/custom_components/bytewatt/api/neovolt_client.py
@@ -2,7 +2,8 @@
 import logging
 import asyncio
 import aiohttp
-from typing import Dict, Any, Optional
+import json
+from typing import Dict, Any, Optional, List
 from datetime import datetime, timedelta
 
 from homeassistant.core import HomeAssistant
@@ -15,6 +16,40 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_TIMEOUT = 30
 DEFAULT_BASE_URL = "https://monitor.byte-watt.com"
+RATE_LIMIT_BACKOFF_SECONDS = 10
+
+
+def _normalize_cycle_windows(
+    raw_windows: Optional[List[Dict[str, Any]]],
+    default_power: int,
+    default_limit: float,
+) -> List[Dict[str, Any]]:
+    """Normalize charge/discharge window definitions for ByteWatt API."""
+    if not raw_windows:
+        return []
+
+    normalized: List[Dict[str, Any]] = []
+    for idx, item in enumerate(raw_windows, start=1):
+        if not isinstance(item, dict):
+            continue
+        begin = item.get("beginTime") or item.get("start") or item.get("begin")
+        end = item.get("endTime") or item.get("end")
+        if not begin or not end:
+            continue
+        normalized.append(
+            {
+                "chargeLimit": float(item.get("chargeLimit", default_limit)),
+                "beginTime": str(begin),
+                "endTime": str(end),
+                "sort": int(item.get("sort", idx)),
+                "chargePower": int(item.get("chargePower", default_power)),
+                "weeks": item.get("weeks") or [7, 1, 2, 3, 4, 5, 6],
+                "feedMode": int(item.get("feedMode", 0)),
+                "equipGroupId": int(item.get("equipGroupId", 0)),
+                "feedPower": int(item.get("feedPower", 0)),
+            }
+        )
+    return normalized
 
 class NeovoltClient:
     """API Client for Neovolt battery systems."""
@@ -36,6 +71,7 @@ class NeovoltClient:
         self._settings_cache = None
         self._fresh_settings_update = False
         self._settings_update_time = None
+        self._control_variant_data: Dict[str, Any] = {}
     
     async def async_login(self) -> bool:
         """Login to the Neovolt API using encrypted password."""
@@ -61,6 +97,10 @@ class NeovoltClient:
                 )
                 
                 if response.status != 200:
+                    if response.status == 429:
+                        _LOGGER.warning("Rate limited fetching device list, backing off for %ss", RATE_LIMIT_BACKOFF_SECONDS)
+                        await asyncio.sleep(RATE_LIMIT_BACKOFF_SECONDS)
+                        return None
                     _LOGGER.error(
                         "Login failed with status %s: %s", 
                         response.status, 
@@ -114,6 +154,10 @@ class NeovoltClient:
                 )
                 
                 if response.status != 200:
+                    if response.status == 429:
+                        _LOGGER.warning("Rate limited fetching battery data, backing off for %ss", RATE_LIMIT_BACKOFF_SECONDS)
+                        await asyncio.sleep(RATE_LIMIT_BACKOFF_SECONDS)
+                        return None
                     _LOGGER.error(
                         "Fallback login failed with status %s: %s", 
                         response.status, 
@@ -500,6 +544,165 @@ class NeovoltClient:
             _LOGGER.error("Error fetching battery data: %s", error)
             return None
     
+    async def async_get_inverter_list(self) -> Optional[List[Dict[str, Any]]]:
+        """
+        Get the list of inverters from the API.
+        
+        Returns:
+            List of inverter dictionaries with their SN and capabilities
+        """
+        if not self.token:
+            if not await self.async_login():
+                return None
+        
+        # Use the correct endpoint discovered from browser traffic
+        url = f"{self.base_url}/api/stable/home/getCustomMenuEssList"
+        params = {"inverterMode": "0"}
+        
+        # Use extended headers like the web interface
+        current_date = dt_util.now().strftime("%Y-%m-%d %H:%M:%S")
+        
+        headers = self._get_auth_headers()
+        headers.update({
+            "Accept": "application/json, text/plain, */*",
+            "Accept-Language": "en-GB,en;q=0.9",
+            "language": "en-US",
+            "operationDate": current_date,
+            "platform": "AK9D8H",
+            "System": "alphacloud",
+            "Referer": f"{self.base_url}/basicSettings/systemSettings"
+        })
+        
+        try:
+            async with asyncio.timeout(DEFAULT_TIMEOUT):
+                response = await self.session.get(
+                    url=url,
+                    params=params,
+                    headers=headers
+                )
+                
+                if response.status != 200:
+                    _LOGGER.error("Failed to get inverter list: status %s", response.status)
+                    return None
+                
+                result = await response.json()
+                
+                if result.get("code") != 200:
+                    _LOGGER.error("Failed to get inverter list: code %s", result.get("code"))
+                    return None
+                
+                inverters = result.get("data", [])
+                _LOGGER.info("Discovered %d inverters from API", len(inverters))
+                
+                # Log key info for each inverter
+                for inv in inverters:
+                    _LOGGER.info(
+                        "Inverter: %s, onGridCap: %s, popv: %s, cobat: %s",
+                        inv.get("sysSn"),
+                        inv.get("onGridCap"),
+                        inv.get("popv"),
+                        inv.get("cobat")
+                    )
+                
+                return inverters
+                
+        except Exception as e:
+            _LOGGER.error("Error fetching inverter list: %s", e)
+            return None
+    
+    async def async_get_per_inverter_data(self, inverter_sns: List[str] = None) -> Optional[Dict[str, Dict[str, Any]]]:
+        """
+        Get power data for each inverter individually.
+        
+        Args:
+            inverter_sns: List of inverter serial numbers to query. 
+                          If None, will try to discover from API.
+        
+        Returns:
+            Dict mapping inverter serial numbers to their power data
+        """
+        if not self.token:
+            if not await self.async_login():
+                return None
+        
+        # If no SNs provided, try to discover them
+        if not inverter_sns:
+            inverters = await self.async_get_inverter_list()
+            if inverters:
+                inverter_sns = [inv.get("sysSn") for inv in inverters if inv.get("sysSn")]
+                _LOGGER.info("Auto-discovered inverters: %s", inverter_sns)
+        
+        if not inverter_sns:
+            _LOGGER.warning("No inverter SNs available for per-inverter queries")
+            return None
+        
+        inverter_data = {}
+        
+        # Use timezone-aware datetime
+        current_date = dt_util.now().strftime("%Y-%m-%d %H:%M:%S")
+        
+        headers = self._get_auth_headers()
+        headers.update({
+            "Accept": "application/json, text/plain, */*",
+            "language": "en-US",
+            "operationDate": current_date,
+            "platform": "AK9D8H",
+            "System": "alphacloud"
+        })
+        
+        url = f"{self.base_url}/api/report/energyStorage/getLastPowerData"
+        
+        for sn in inverter_sns:
+            try:
+                params = {
+                    "sysSn": sn,
+                    "stationId": ""
+                }
+                
+                async with asyncio.timeout(DEFAULT_TIMEOUT):
+                    response = await self.session.get(
+                        url=url,
+                        params=params,
+                        headers=headers
+                    )
+                    
+                    if response.status != 200:
+                        _LOGGER.warning(f"Failed to get data for inverter {sn}: status {response.status}")
+                        continue
+                    
+                    result = await response.json()
+                    
+                    if result.get("code") != 0 and result.get("code") != 200:
+                        _LOGGER.warning(f"Failed to get data for inverter {sn}: code {result.get('code')}")
+                        continue
+                    
+                    data = result.get("data", {})
+                    if data:
+                        inverter_data[sn] = {
+                            "ppv": data.get("ppv", 0),
+                            "pbat": data.get("pbat", 0),
+                            "pgrid": data.get("pgrid", 0),
+                            "pload": data.get("pload", 0),
+                            "soc": data.get("soc", 0),
+                            "ppv1": data.get("ppv1", 0),
+                            "ppv2": data.get("ppv2", 0),
+                            "ppv3": data.get("ppv3", 0),
+                            "ppv4": data.get("ppv4", 0),
+                            "prealL1": data.get("prealL1", 0),
+                            "prealL2": data.get("prealL2", 0),
+                            "prealL3": data.get("prealL3", 0),
+                            "forceChargeMode": data.get("forceChargeMode", False),
+                            "inverterMode": data.get("inverterMode"),
+                        }
+                        _LOGGER.debug(f"Got data for inverter {sn}: PPV={data.get('ppv')}, PGrid={data.get('pgrid')}, PBat={data.get('pbat')}")
+                
+            except Exception as e:
+                _LOGGER.error(f"Error fetching data for inverter {sn}: {e}")
+                continue
+        
+        _LOGGER.debug(f"Per-inverter data: {inverter_data}")
+        return inverter_data if inverter_data else None
+    
     def _get_auth_headers(self) -> Dict[str, str]:
         """Get the authentication headers."""
         return {
@@ -524,14 +727,403 @@ class NeovoltClient:
         except Exception as error:
             _LOGGER.error("Error fetching battery settings: %s", error)
             return None
+
+    async def async_force_charge(
+        self,
+        system_id: str,
+        sys_sn: Optional[str] = None,
+        limit: int = 95,
+        charge_power: Optional[int] = None,
+    ) -> bool:
+        """Start force charge for a system."""
+        payload: Dict[str, Any] = {
+            "id": system_id,
+            "batUseCap": int(limit),
+        }
+        if sys_sn:
+            payload["sysSn"] = sys_sn
+        if charge_power is not None:
+            payload["chargePower"] = int(charge_power)
+
+        response = await self._async_put("api/iterate/sysSet/forceCharge", payload)
+        if response and response.get("code") == 200:
+            return True
+        _LOGGER.error("Force charge failed for %s (%s): %s", system_id, sys_sn, response)
+        return False
+
+    async def async_stop_force_charge(self, system_id: str) -> bool:
+        """Stop force charge for a system."""
+        response = await self._async_put(
+            "api/iterate/sysSet/stopCharge",
+            {"id": system_id},
+        )
+        if response and response.get("code") == 200:
+            return True
+        _LOGGER.error("Stop force charge failed for %s: %s", system_id, response)
+        return False
+
+    async def async_get_force_charge_status(self, system_id: str) -> Optional[bool]:
+        """Get current force-charge status for a system."""
+        response = await self._async_get(f"api/iterate/sysSet/getForceChargeStatus?id={system_id}")
+        if response and response.get("code") == 200:
+            return response.get("data")
+        return None
+
+    async def async_get_force_charge_limit(self, system_id: str) -> Optional[float]:
+        """Get current force-charge limit for a system."""
+        response = await self._async_get(f"api/iterate/sysSet/getForceChargeLimit?id={system_id}")
+        if response and response.get("code") == 200:
+            try:
+                return float(response.get("data"))
+            except (TypeError, ValueError):
+                return None
+        return None
+
+    async def async_get_cycle_strategy(self, system_id: str) -> Optional[Dict[str, Any]]:
+        """Get cycle-strategy control payload for a system."""
+        response = await self._async_get(f"api/iterate/sysSet/getCycleStrategy?id={system_id}")
+        if response and response.get("code") == 200:
+            return response.get("data")
+        return None
+
+    async def async_get_system_detail(self, system_id: str) -> Optional[Dict[str, Any]]:
+        """Get system detail for a system id."""
+        response = await self._async_get(f"api/stable/essSystemData/getSystemDetail?systemId={system_id}")
+        if response and response.get("code") == 200:
+            return response.get("data")
+        return None
+
+    async def async_get_system_setting_menu_visible(self, sys_sn: str) -> Optional[Dict[str, Any]]:
+        """Get menu/capability flags for an inverter SN."""
+        response = await self._async_get(f"api/base/columnControl/getSystemSettingMenuVisible?sysSn={sys_sn}")
+        if response and response.get("code") == 200:
+            return response.get("data")
+        return None
+
+    async def async_detect_control_variant(self, preferred_variant: str = "auto") -> Dict[str, Any]:
+        """Detect the active Byte-Watt control variant and collect related metadata."""
+        result: Dict[str, Any] = {
+            "configured_variant": preferred_variant,
+            "detected_variant": "charge_config",
+            "variant_source": "fallback",
+            "system_id": None,
+            "system_detail": None,
+            "cycle_strategy": None,
+            "force_charge_status": None,
+            "force_charge_limit": None,
+            "menu_visible": {},
+            "summary": "legacy charge-config controls",
+        }
+
+        try:
+            inverter_list = await self.async_get_inverter_list()
+            if inverter_list:
+                result["inverter_list"] = inverter_list
+                host_candidate = inverter_list[0]
+                result["system_id"] = host_candidate.get("systemId")
+                result["host_sys_sn"] = host_candidate.get("sysSn")
+
+                menu_visible = {}
+                for inv in inverter_list:
+                    sys_sn = inv.get("sysSn")
+                    if not sys_sn:
+                        continue
+                    visible = await self.async_get_system_setting_menu_visible(sys_sn)
+                    if visible is not None:
+                        menu_visible[sys_sn] = visible
+                result["menu_visible"] = menu_visible
+
+                # Evaluate all known systems to select best cycle-strategy target.
+                system_candidates = []
+                for inv in inverter_list:
+                    candidate_system_id = inv.get("systemId")
+                    if not candidate_system_id:
+                        continue
+                    candidate_cycle = await self.async_get_cycle_strategy(candidate_system_id)
+                    candidate_detail = await self.async_get_system_detail(candidate_system_id)
+                    has_schedule = bool((candidate_cycle or {}).get("dayDischargeTimeList") or (candidate_cycle or {}).get("dayChargeTimeList"))
+                    try:
+                        poinv = float((candidate_cycle or {}).get("poinv") or inv.get("poinv") or (candidate_detail or {}).get("poinv") or 0)
+                    except (TypeError, ValueError):
+                        poinv = 0.0
+                    system_candidates.append({
+                        "system_id": candidate_system_id,
+                        "sys_sn": inv.get("sysSn"),
+                        "has_schedule": has_schedule,
+                        "poinv": poinv,
+                        "cycle_strategy": candidate_cycle,
+                        "system_detail": candidate_detail,
+                    })
+
+                if system_candidates:
+                    host_system_id = result.get("system_id")
+                    sorted_candidates = sorted(
+                        system_candidates,
+                        key=lambda c: (
+                            0 if c["system_id"] == host_system_id else 1,
+                            0 if c["has_schedule"] else 1,
+                            -c["poinv"],
+                            c["system_id"],
+                        ),
+                    )
+                    target = sorted_candidates[0]
+                    result["target_system_id"] = target["system_id"]
+                    result["target_sys_sn"] = target["sys_sn"]
+                    if target["system_id"] == host_system_id:
+                        result["target_selection_source"] = "auto_host_primary"
+                    elif target["has_schedule"]:
+                        result["target_selection_source"] = "auto_scheduled_fallback"
+                    else:
+                        result["target_selection_source"] = "auto_largest_poinv_fallback"
+                    result["system_candidates"] = [
+                        {
+                            "system_id": c["system_id"],
+                            "sys_sn": c["sys_sn"],
+                            "has_schedule": c["has_schedule"],
+                            "poinv": c["poinv"],
+                        }
+                        for c in sorted_candidates
+                    ]
+
+            # Use selected target system for control-variant and cycle-strategy evaluation,
+            # while still keeping the original discovered host system id in `system_id`.
+            control_system_id = result.get("target_system_id") or result.get("system_id")
+            if control_system_id:
+                result["control_system_id"] = control_system_id
+                result["system_detail"] = await self.async_get_system_detail(control_system_id)
+                result["cycle_strategy"] = await self.async_get_cycle_strategy(control_system_id)
+                result["force_charge_status"] = await self.async_get_force_charge_status(control_system_id)
+                result["force_charge_limit"] = await self.async_get_force_charge_limit(control_system_id)
+
+            cycle_strategy = result.get("cycle_strategy") or {}
+            result["cycle_charge_active"] = bool(
+                (cycle_strategy.get("gridChargeCycle") or 0) == 1
+                and len(cycle_strategy.get("dayChargeTimeList") or []) > 0
+            )
+            result["cycle_discharge_active"] = bool(
+                (cycle_strategy.get("ctrDisCycle") or 0) == 1
+                and len(cycle_strategy.get("dayDischargeTimeList") or []) > 0
+            )
+            result["cycle_charge_count"] = len(cycle_strategy.get("dayChargeTimeList") or [])
+            result["cycle_discharge_count"] = len(cycle_strategy.get("dayDischargeTimeList") or [])
+            result["cycle_charge_windows_json"] = f"{len(cycle_strategy.get('dayChargeTimeList') or [])} windows"
+            result["cycle_discharge_windows_json"] = f"{len(cycle_strategy.get('dayDischargeTimeList') or [])} windows"
+            first_charge = (cycle_strategy.get("dayChargeTimeList") or [None])[0]
+            first_discharge = (cycle_strategy.get("dayDischargeTimeList") or [None])[0]
+            result["cycle_charge_start"] = first_charge.get("beginTime") if first_charge else None
+            result["cycle_charge_end"] = first_charge.get("endTime") if first_charge else None
+            result["cycle_discharge_start"] = first_discharge.get("beginTime") if first_discharge else None
+            result["cycle_discharge_end"] = first_discharge.get("endTime") if first_discharge else None
+            if cycle_strategy and any(
+                cycle_strategy.get(key) not in (None, 0, [], {})
+                for key in ["dayChargeTimeList", "dayDischargeTimeList", "weekChargeTimeList", "weekDischargeTimeList", "gridChargeCycle", "ctrDisCycle"]
+            ):
+                if first_discharge:
+                    summary = (
+                        "cycle-strategy controls active "
+                        f"({first_discharge.get('beginTime')}->{first_discharge.get('endTime')}, "
+                        f"limit={first_discharge.get('chargeLimit')}, power={first_discharge.get('chargePower')})"
+                    )
+                else:
+                    summary = "cycle-strategy controls active"
+                result["detected_variant"] = "cycle_strategy"
+                result["variant_source"] = "cycle_strategy_endpoint"
+                result["summary"] = summary
+            else:
+                result["detected_variant"] = "charge_config"
+                result["variant_source"] = "charge_config_endpoint"
+                result["summary"] = "legacy charge-config controls active"
+
+            if preferred_variant and preferred_variant != "auto":
+                result["effective_variant"] = preferred_variant
+                result["variant_source"] = "user_config"
+            else:
+                result["effective_variant"] = result["detected_variant"]
+
+            self._control_variant_data = result
+            return result
+        except Exception as error:
+            _LOGGER.error("Error detecting control variant: %s", error)
+            if preferred_variant and preferred_variant != "auto":
+                result["effective_variant"] = preferred_variant
+                result["variant_source"] = "user_config_fallback"
+            else:
+                result["effective_variant"] = result["detected_variant"]
+            self._control_variant_data = result
+            return result
+
+    async def async_update_cycle_strategy(
+        self,
+        system_id: str,
+        charge_windows: Optional[List[Dict[str, Any]]] = None,
+        discharge_windows: Optional[List[Dict[str, Any]]] = None,
+        charge_start_time: str = None,
+        charge_end_time: str = None,
+        charge_cap: int = None,
+        charge_power: int = None,
+        charge_enabled: bool = None,
+        discharge_start_time: str = None,
+        discharge_end_time: str = None,
+        minimum_soc: int = None,
+        discharge_power: int = None,
+        discharge_enabled: bool = None,
+    ) -> bool:
+        """Update the primary cycle-strategy discharge window.
+
+        This currently supports a conservative subset of cycle strategy fields,
+        preserving all other server-provided values.
+        """
+        try:
+            current = await self.async_get_cycle_strategy(system_id)
+            if not current:
+                _LOGGER.error("Unable to fetch current cycle strategy for %s", system_id)
+                return False
+
+            payload = dict(current)
+            payload["id"] = system_id
+
+            charge_list = list(payload.get("dayChargeTimeList") or [])
+            discharge_list = list(payload.get("dayDischargeTimeList") or [])
+
+            if charge_windows is not None:
+                charge_list = _normalize_cycle_windows(
+                    charge_windows,
+                    default_power=int(payload.get("poinv") or 5000),
+                    default_limit=float(charge_cap or 80),
+                )
+                payload["gridChargeCycle"] = 1 if charge_list else 0
+
+            if discharge_windows is not None:
+                discharge_list = _normalize_cycle_windows(
+                    discharge_windows,
+                    default_power=int(payload.get("poinv") or 5000),
+                    default_limit=float(minimum_soc or payload.get("batUseCap") or 10),
+                )
+                payload["ctrDisCycle"] = 1 if discharge_list else 0
+
+            if charge_windows is None and charge_enabled is False:
+                payload["gridChargeCycle"] = 0
+                charge_list = []
+            elif charge_windows is None and any(v is not None for v in [charge_start_time, charge_end_time, charge_cap, charge_power, charge_enabled]):
+                payload["gridChargeCycle"] = 1 if charge_enabled is not False else 0
+                if not charge_list:
+                    charge_list = [{
+                        "chargeLimit": float(charge_cap or 80),
+                        "beginTime": charge_start_time or "00:00",
+                        "endTime": charge_end_time or "00:00",
+                        "sort": 1,
+                        "chargePower": int(charge_power or payload.get("poinv") or 5000),
+                        "weeks": [7, 1, 2, 3, 4, 5, 6],
+                        "feedMode": 0,
+                        "equipGroupId": 0,
+                        "feedPower": 0,
+                    }]
+
+                primary_charge = dict(charge_list[0])
+                if charge_start_time is not None:
+                    primary_charge["beginTime"] = charge_start_time
+                if charge_end_time is not None:
+                    primary_charge["endTime"] = charge_end_time
+                if charge_cap is not None:
+                    primary_charge["chargeLimit"] = float(charge_cap)
+                if charge_power is not None:
+                    primary_charge["chargePower"] = int(charge_power)
+                primary_charge.setdefault("sort", 1)
+                primary_charge.setdefault("weeks", [7, 1, 2, 3, 4, 5, 6])
+                primary_charge.setdefault("feedMode", 0)
+                primary_charge.setdefault("equipGroupId", 0)
+                primary_charge.setdefault("feedPower", 0)
+                charge_list[0] = primary_charge
+
+            if discharge_windows is None and discharge_enabled is False:
+                payload["ctrDisCycle"] = 0
+                discharge_list = []
+            elif discharge_windows is None:
+                payload["ctrDisCycle"] = 1
+                if not discharge_list:
+                    discharge_list = [{
+                        "chargeLimit": float(payload.get("batUseCap", 10)),
+                        "beginTime": discharge_start_time or "16:00",
+                        "endTime": discharge_end_time or "07:15",
+                        "sort": 1,
+                        "chargePower": int(discharge_power or payload.get("poinv") or 5000),
+                        "weeks": [7, 1, 2, 3, 4, 5, 6],
+                        "feedMode": 0,
+                        "equipGroupId": 0,
+                        "feedPower": 0,
+                    }]
+
+                primary = dict(discharge_list[0])
+                if discharge_start_time is not None:
+                    primary["beginTime"] = discharge_start_time
+                if discharge_end_time is not None:
+                    primary["endTime"] = discharge_end_time
+                if minimum_soc is not None:
+                    primary["chargeLimit"] = float(minimum_soc)
+                    payload["batUseCap"] = float(minimum_soc)
+                if discharge_power is not None:
+                    primary["chargePower"] = int(discharge_power)
+                primary.setdefault("sort", 1)
+                primary.setdefault("weeks", [7, 1, 2, 3, 4, 5, 6])
+                primary.setdefault("feedMode", 0)
+                primary.setdefault("equipGroupId", 0)
+                primary.setdefault("feedPower", 0)
+                discharge_list[0] = primary
+
+            charge_list = sorted(charge_list, key=lambda item: int(item.get("sort", 0)))
+            discharge_list = sorted(discharge_list, key=lambda item: int(item.get("sort", 0)))
+
+            payload["dayChargeTimeList"] = charge_list
+            payload["dayDischargeTimeList"] = discharge_list
+            payload["chargeTimeList"] = charge_list if charge_list else None
+            payload["dischargeTimeList"] = discharge_list if discharge_list else None
+
+            _LOGGER.info(
+                "Updating cycle strategy for %s with %s charge windows and %s discharge windows",
+                system_id,
+                len(charge_list),
+                len(discharge_list),
+            )
+            _LOGGER.debug(
+                "Cycle strategy payload summary: %s",
+                json.dumps(
+                    {
+                        "id": payload.get("id"),
+                        "gridChargeCycle": payload.get("gridChargeCycle"),
+                        "ctrDisCycle": payload.get("ctrDisCycle"),
+                        "chargeTimeList": payload.get("chargeTimeList"),
+                        "dischargeTimeList": payload.get("dischargeTimeList"),
+                    }
+                )[:4000],
+            )
+
+            endpoint = "api/iterate/sysSet/setCycleStrategy"
+            response = await self._async_put(endpoint, payload)
+            if response and response.get("code") == 200 and response.get("msg") == "Success":
+                _LOGGER.info("Successfully updated cycle strategy for %s", system_id)
+                return True
+
+            _LOGGER.error("Failed to update cycle strategy for %s: %s", system_id, response)
+            return False
+        except Exception as error:
+            _LOGGER.error("Error updating cycle strategy for %s: %s", system_id, error)
+            return False
     
     async def async_update_battery_settings(self, 
                                           discharge_start_time: str = None,
                                           discharge_end_time: str = None,
                                           charge_start_time: str = None,
                                           charge_end_time: str = None,
+                                          charge_start_time_2: str = None,
+                                          charge_end_time_2: str = None,
+                                          discharge_start_time_2: str = None,
+                                          discharge_end_time_2: str = None,
                                           minimum_soc: int = None,
                                           charge_cap: int = None,
+                                          ups_reserve: int = None,
+                                          charge_mode_setting: int = None,
+                                          export_limit_w1: int = None,
+                                          export_limit_w2: int = None,
                                           discharge_time_control: bool = None,
                                           grid_charging: bool = None) -> bool:
         """Update battery settings."""
@@ -544,14 +1136,22 @@ class NeovoltClient:
             
             # Use the async method directly
             result = await settings_api.update_battery_settings(
-                discharge_start_time,
-                discharge_end_time,
-                charge_start_time,
-                charge_end_time,
-                minimum_soc,
-                charge_cap,
-                discharge_time_control,
-                grid_charging
+                discharge_start_time=discharge_start_time,
+                discharge_end_time=discharge_end_time,
+                charge_start_time=charge_start_time,
+                charge_end_time=charge_end_time,
+                charge_start_time_2=charge_start_time_2,
+                charge_end_time_2=charge_end_time_2,
+                discharge_start_time_2=discharge_start_time_2,
+                discharge_end_time_2=discharge_end_time_2,
+                minimum_soc=minimum_soc,
+                charge_cap=charge_cap,
+                ups_reserve=ups_reserve,
+                charge_mode_setting=charge_mode_setting,
+                export_limit_w1=export_limit_w1,
+                export_limit_w2=export_limit_w2,
+                discharge_time_control=discharge_time_control,
+                grid_charging=grid_charging,
             )
             
             # If successful, set fresh update flag and schedule auto-fetch from API
@@ -624,11 +1224,23 @@ class NeovoltClient:
     
     async def _async_get(self, endpoint: str) -> Optional[Dict[str, Any]]:
         """Make an async GET request."""
+        if not self.token and not await self.async_login():
+            return None
         url = f"{self.base_url}/{endpoint}"
         headers = self._get_auth_headers()
         
         try:
             async with self.session.get(url, headers=headers, timeout=DEFAULT_TIMEOUT) as response:
+                if response.status == 429:
+                    _LOGGER.warning("Rate limited on GET %s, backing off for %ss", endpoint, RATE_LIMIT_BACKOFF_SECONDS)
+                    await asyncio.sleep(RATE_LIMIT_BACKOFF_SECONDS)
+                    return None
+                if response.status == 401:
+                    _LOGGER.warning("GET %s returned 401, refreshing token", endpoint)
+                    self.token = None
+                    if await self.async_login():
+                        return await self._async_get(endpoint)
+                    return None
                 if response.status == 200:
                     return await response.json()
                 else:
@@ -640,6 +1252,8 @@ class NeovoltClient:
     
     async def _async_post(self, endpoint: str, data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Make an async POST request."""
+        if not self.token and not await self.async_login():
+            return None
         url = f"{self.base_url}/{endpoint}"
         headers = self._get_auth_headers()
         # Add specific headers for settings update
@@ -653,6 +1267,16 @@ class NeovoltClient:
         
         try:
             async with self.session.post(url, headers=headers, json=data, timeout=DEFAULT_TIMEOUT) as response:
+                if response.status == 429:
+                    _LOGGER.warning("Rate limited on POST %s, backing off for %ss", endpoint, RATE_LIMIT_BACKOFF_SECONDS)
+                    await asyncio.sleep(RATE_LIMIT_BACKOFF_SECONDS)
+                    return None
+                if response.status == 401:
+                    _LOGGER.warning("POST %s returned 401, refreshing token", endpoint)
+                    self.token = None
+                    if await self.async_login():
+                        return await self._async_post(endpoint, data)
+                    return None
                 if response.status == 200:
                     return await response.json()
                 else:
@@ -668,6 +1292,8 @@ class NeovoltClient:
     
     async def _async_put(self, endpoint: str, data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Make an async PUT request."""
+        if not self.token and not await self.async_login():
+            return None
         url = f"{self.base_url}/{endpoint}"
         headers = self._get_auth_headers()
         # Add specific headers for settings update
@@ -681,6 +1307,16 @@ class NeovoltClient:
         
         try:
             async with self.session.put(url, headers=headers, json=data, timeout=DEFAULT_TIMEOUT) as response:
+                if response.status == 429:
+                    _LOGGER.warning("Rate limited on PUT %s, backing off for %ss", endpoint, RATE_LIMIT_BACKOFF_SECONDS)
+                    await asyncio.sleep(RATE_LIMIT_BACKOFF_SECONDS)
+                    return None
+                if response.status == 401:
+                    _LOGGER.warning("PUT %s returned 401, refreshing token", endpoint)
+                    self.token = None
+                    if await self.async_login():
+                        return await self._async_put(endpoint, data)
+                    return None
                 if response.status == 200:
                     return await response.json()
                 else:

--- a/custom_components/bytewatt/api/settings.py
+++ b/custom_components/bytewatt/api/settings.py
@@ -222,8 +222,16 @@ class BatterySettingsAPI:
                               discharge_end_time=None,
                               charge_start_time=None,
                               charge_end_time=None,
+                              charge_start_time_2=None,
+                              charge_end_time_2=None,
+                              discharge_start_time_2=None,
+                              discharge_end_time_2=None,
                               minimum_soc=None,
                               charge_cap=None,
+                              ups_reserve=None,
+                              charge_mode_setting=None,
+                              export_limit_w1=None,
+                              export_limit_w2=None,
                               discharge_time_control=None,
                               grid_charging=None,
                               max_retries: int = 5, 
@@ -257,7 +265,11 @@ class BatterySettingsAPI:
         
         # Check if any changes were made
         if (discharge_start is None and discharge_end is None and 
-            charge_start is None and charge_end is None and min_soc is None and max_charge_cap is None and
+            charge_start is None and charge_end is None and
+            charge_start_time_2 is None and charge_end_time_2 is None and
+            discharge_start_time_2 is None and discharge_end_time_2 is None and
+            min_soc is None and max_charge_cap is None and ups_reserve is None and
+            charge_mode_setting is None and export_limit_w1 is None and export_limit_w2 is None and
             ctr_dis_value is None and grid_charge_value is None):
             _LOGGER.warning("No valid battery settings provided, nothing to update")
             return False
@@ -284,6 +296,22 @@ class BatterySettingsAPI:
         if charge_end is not None:
             settings.time_chae1a = charge_end
             _LOGGER.debug(f"Updating charge end time to {charge_end}")
+
+        if charge_start_time_2 is not None:
+            settings.time_chaf2a = sanitize_time_format(charge_start_time_2) or settings.time_chaf2a
+            _LOGGER.debug(f"Updating charge start time 2 to {settings.time_chaf2a}")
+
+        if charge_end_time_2 is not None:
+            settings.time_chae2a = sanitize_time_format(charge_end_time_2) or settings.time_chae2a
+            _LOGGER.debug(f"Updating charge end time 2 to {settings.time_chae2a}")
+
+        if discharge_start_time_2 is not None:
+            settings.time_disf2a = sanitize_time_format(discharge_start_time_2) or settings.time_disf2a
+            _LOGGER.debug(f"Updating discharge start time 2 to {settings.time_disf2a}")
+
+        if discharge_end_time_2 is not None:
+            settings.time_dise2a = sanitize_time_format(discharge_end_time_2) or settings.time_dise2a
+            _LOGGER.debug(f"Updating discharge end time 2 to {settings.time_dise2a}")
         
         if min_soc is not None:
             settings.bat_use_cap = min_soc
@@ -292,6 +320,34 @@ class BatterySettingsAPI:
         if max_charge_cap is not None:
             settings.bat_high_cap = str(max_charge_cap)
             _LOGGER.debug(f"Updating charge cap to {max_charge_cap}%")
+
+        if ups_reserve is not None:
+            try:
+                settings.additional_fields["upsReserve"] = int(ups_reserve)
+                _LOGGER.debug(f"Updating UPS reserve to {ups_reserve}")
+            except (ValueError, TypeError):
+                _LOGGER.error(f"Invalid ups_reserve value: {ups_reserve}")
+
+        if charge_mode_setting is not None:
+            try:
+                settings.additional_fields["chargeModeSetting"] = int(charge_mode_setting)
+                _LOGGER.debug(f"Updating charge mode setting to {charge_mode_setting}")
+            except (ValueError, TypeError):
+                _LOGGER.error(f"Invalid charge_mode_setting value: {charge_mode_setting}")
+
+        if export_limit_w1 is not None:
+            try:
+                settings.additional_fields["timeExpLimW1"] = int(export_limit_w1)
+                _LOGGER.debug(f"Updating export limit window 1 to {export_limit_w1}")
+            except (ValueError, TypeError):
+                _LOGGER.error(f"Invalid export_limit_w1 value: {export_limit_w1}")
+
+        if export_limit_w2 is not None:
+            try:
+                settings.additional_fields["timeExpLimW2"] = int(export_limit_w2)
+                _LOGGER.debug(f"Updating export limit window 2 to {export_limit_w2}")
+            except (ValueError, TypeError):
+                _LOGGER.error(f"Invalid export_limit_w2 value: {export_limit_w2}")
         
         if ctr_dis_value is not None:
             settings.ctr_dis = ctr_dis_value

--- a/custom_components/bytewatt/bytewatt_client.py
+++ b/custom_components/bytewatt/bytewatt_client.py
@@ -19,36 +19,127 @@ class ByteWattClient:
         self.username = username
         self.password = password
         self.api_client = NeovoltClient(hass, username, password)
+        self._api_lock = asyncio.Lock()
     
     async def initialize(self) -> bool:
         """Initialize or re-initialize the client."""
-        return await self.api_client.async_login()
+        async with self._api_lock:
+            return await self.api_client.async_login()
     
     async def get_battery_data(self, station_id: str = None) -> Optional[Dict[str, Any]]:
         """Get battery data from the API."""
-        return await self.api_client.async_get_battery_data(station_id)
+        async with self._api_lock:
+            return await self.api_client.async_get_battery_data(station_id)
     
     async def get_device_list(self) -> Optional[Dict[str, Any]]:
         """Get list of devices from the API."""
-        return await self.api_client.async_get_device_list()
+        async with self._api_lock:
+            return await self.api_client.async_get_device_list()
     
     async def update_battery_settings(self, 
                                     discharge_start_time: str = None,
                                     discharge_end_time: str = None,
                                     charge_start_time: str = None,
                                     charge_end_time: str = None,
+                                    charge_start_time_2: str = None,
+                                    charge_end_time_2: str = None,
+                                    discharge_start_time_2: str = None,
+                                    discharge_end_time_2: str = None,
                                     minimum_soc: int = None,
                                     charge_cap: int = None,
+                                    ups_reserve: int = None,
+                                    charge_mode_setting: int = None,
+                                    export_limit_w1: int = None,
+                                    export_limit_w2: int = None,
                                     discharge_time_control: bool = None,
                                     grid_charging: bool = None) -> bool:
         """Update battery settings."""
-        return await self.api_client.async_update_battery_settings(
-            discharge_start_time=discharge_start_time,
-            discharge_end_time=discharge_end_time,
-            charge_start_time=charge_start_time,
-            charge_end_time=charge_end_time,
-            minimum_soc=minimum_soc,
-            charge_cap=charge_cap,
-            discharge_time_control=discharge_time_control,
-            grid_charging=grid_charging
-        )
+        async with self._api_lock:
+            return await self.api_client.async_update_battery_settings(
+                discharge_start_time=discharge_start_time,
+                discharge_end_time=discharge_end_time,
+                charge_start_time=charge_start_time,
+                charge_end_time=charge_end_time,
+                charge_start_time_2=charge_start_time_2,
+                charge_end_time_2=charge_end_time_2,
+                discharge_start_time_2=discharge_start_time_2,
+                discharge_end_time_2=discharge_end_time_2,
+                minimum_soc=minimum_soc,
+                charge_cap=charge_cap,
+                ups_reserve=ups_reserve,
+                charge_mode_setting=charge_mode_setting,
+                export_limit_w1=export_limit_w1,
+                export_limit_w2=export_limit_w2,
+                discharge_time_control=discharge_time_control,
+                grid_charging=grid_charging
+            )
+
+    async def detect_control_variant(self, preferred_variant: str = "auto") -> Dict[str, Any]:
+        """Detect active Byte-Watt control variant."""
+        async with self._api_lock:
+            return await self.api_client.async_detect_control_variant(preferred_variant)
+
+    async def update_cycle_strategy(
+        self,
+        system_id: str,
+        charge_windows: Optional[List[Dict[str, Any]]] = None,
+        discharge_windows: Optional[List[Dict[str, Any]]] = None,
+        charge_start_time: str = None,
+        charge_end_time: str = None,
+        charge_cap: int = None,
+        charge_power: int = None,
+        charge_enabled: bool = None,
+        discharge_start_time: str = None,
+        discharge_end_time: str = None,
+        minimum_soc: int = None,
+        discharge_power: int = None,
+        discharge_enabled: bool = None,
+    ) -> bool:
+        """Update primary cycle-strategy discharge settings."""
+        async with self._api_lock:
+            return await self.api_client.async_update_cycle_strategy(
+                system_id=system_id,
+                charge_windows=charge_windows,
+                discharge_windows=discharge_windows,
+                charge_start_time=charge_start_time,
+                charge_end_time=charge_end_time,
+                charge_cap=charge_cap,
+                charge_power=charge_power,
+                charge_enabled=charge_enabled,
+                discharge_start_time=discharge_start_time,
+                discharge_end_time=discharge_end_time,
+                minimum_soc=minimum_soc,
+                discharge_power=discharge_power,
+                discharge_enabled=discharge_enabled,
+            )
+
+    async def force_charge(
+        self,
+        system_id: str,
+        sys_sn: Optional[str] = None,
+        limit: int = 95,
+        charge_power: Optional[int] = None,
+    ) -> bool:
+        """Force charge a specific system."""
+        async with self._api_lock:
+            return await self.api_client.async_force_charge(
+                system_id=system_id,
+                sys_sn=sys_sn,
+                limit=limit,
+                charge_power=charge_power,
+            )
+
+    async def stop_force_charge(self, system_id: str) -> bool:
+        """Stop force charge for a specific system."""
+        async with self._api_lock:
+            return await self.api_client.async_stop_force_charge(system_id=system_id)
+
+    async def get_force_charge_status(self, system_id: str) -> Optional[bool]:
+        """Get force-charge status for a specific system."""
+        async with self._api_lock:
+            return await self.api_client.async_get_force_charge_status(system_id=system_id)
+
+    async def get_force_charge_limit(self, system_id: str) -> Optional[float]:
+        """Get force-charge limit for a specific system."""
+        async with self._api_lock:
+            return await self.api_client.async_get_force_charge_limit(system_id=system_id)

--- a/custom_components/bytewatt/config_flow.py
+++ b/custom_components/bytewatt/config_flow.py
@@ -12,8 +12,15 @@ from .const import (
     CONF_USERNAME, 
     CONF_PASSWORD,
     CONF_SCAN_INTERVAL,
+    CONF_INVERTER_SNS,
+    CONF_CONTROL_VARIANT,
+    CONF_CONTROL_TARGET_SYSTEM_ID,
     DEFAULT_SCAN_INTERVAL,
-    MIN_SCAN_INTERVAL
+    MIN_SCAN_INTERVAL,
+    DEFAULT_INVERTER_SNS,
+    DEFAULT_CONTROL_VARIANT,
+    DEFAULT_CONTROL_TARGET_SYSTEM_ID,
+    CONTROL_VARIANT_OPTIONS,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -51,6 +58,15 @@ class ByteWattConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Optional(
                         CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
                     ): vol.All(vol.Coerce(int), vol.Range(min=MIN_SCAN_INTERVAL)),
+                    vol.Optional(
+                        CONF_INVERTER_SNS, default=DEFAULT_INVERTER_SNS
+                    ): str,
+                    vol.Optional(
+                        CONF_CONTROL_VARIANT, default=DEFAULT_CONTROL_VARIANT
+                    ): vol.In(CONTROL_VARIANT_OPTIONS),
+                    vol.Optional(
+                        CONF_CONTROL_TARGET_SYSTEM_ID, default=DEFAULT_CONTROL_TARGET_SYSTEM_ID
+                    ): str,
                 }
             ),
             errors=errors,
@@ -85,6 +101,29 @@ class ByteWattOptionsFlowHandler(config_entries.OptionsFlow):
                             CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
                         ),
                     ): vol.All(vol.Coerce(int), vol.Range(min=MIN_SCAN_INTERVAL)),
+                    vol.Optional(
+                        CONF_INVERTER_SNS,
+                        default=self.config_entry.options.get(
+                            CONF_INVERTER_SNS, DEFAULT_INVERTER_SNS
+                        ),
+                    ): str,
+                    vol.Optional(
+                        CONF_CONTROL_VARIANT,
+                        default=self.config_entry.options.get(
+                            CONF_CONTROL_VARIANT,
+                            self.config_entry.data.get(CONF_CONTROL_VARIANT, DEFAULT_CONTROL_VARIANT),
+                        ),
+                    ): vol.In(CONTROL_VARIANT_OPTIONS),
+                    vol.Optional(
+                        CONF_CONTROL_TARGET_SYSTEM_ID,
+                        default=self.config_entry.options.get(
+                            CONF_CONTROL_TARGET_SYSTEM_ID,
+                            self.config_entry.data.get(
+                                CONF_CONTROL_TARGET_SYSTEM_ID,
+                                DEFAULT_CONTROL_TARGET_SYSTEM_ID,
+                            ),
+                        ),
+                    ): str,
                 }
             ),
         )

--- a/custom_components/bytewatt/const.py
+++ b/custom_components/bytewatt/const.py
@@ -13,6 +13,9 @@ CONF_STALE_CHECKS_THRESHOLD = "stale_checks_threshold"
 CONF_NOTIFY_ON_RECOVERY = "notify_on_recovery"
 CONF_DIAGNOSTICS_MODE = "diagnostics_mode"
 CONF_AUTO_RECONNECT_TIME = "auto_reconnect_time"
+CONF_INVERTER_SNS = "inverter_sns"
+CONF_CONTROL_VARIANT = "control_variant"
+CONF_CONTROL_TARGET_SYSTEM_ID = "control_target_system_id"
 
 # Defaults
 DEFAULT_SCAN_INTERVAL = 60  # 1 minute
@@ -24,6 +27,19 @@ DEFAULT_STALE_CHECKS_THRESHOLD = 3
 DEFAULT_NOTIFY_ON_RECOVERY = True
 DEFAULT_DIAGNOSTICS_MODE = False
 DEFAULT_AUTO_RECONNECT_TIME = "03:30:00"  # 3:30 AM
+DEFAULT_INVERTER_SNS = "25000SP2B5W00252,25000SP2B5W00253"  # Comma-separated list
+
+# Control variants
+CONTROL_VARIANT_AUTO = "auto"
+CONTROL_VARIANT_CHARGE_CONFIG = "charge_config"
+CONTROL_VARIANT_CYCLE_STRATEGY = "cycle_strategy"
+CONTROL_VARIANT_OPTIONS = [
+    CONTROL_VARIANT_AUTO,
+    CONTROL_VARIANT_CHARGE_CONFIG,
+    CONTROL_VARIANT_CYCLE_STRATEGY,
+]
+DEFAULT_CONTROL_VARIANT = CONTROL_VARIANT_AUTO
+DEFAULT_CONTROL_TARGET_SYSTEM_ID = ""
 
 # Services
 SERVICE_SET_DISCHARGE_TIME = "set_discharge_time"  # Legacy service
@@ -36,6 +52,10 @@ SERVICE_UPDATE_BATTERY_SETTINGS = "update_battery_settings"
 SERVICE_FORCE_RECONNECT = "force_reconnect"  # Force client reconnection for troubleshooting
 SERVICE_HEALTH_CHECK = "health_check"  # Check connection health and return diagnostics
 SERVICE_TOGGLE_DIAGNOSTICS = "toggle_diagnostics"  # Toggle diagnostic logging
+SERVICE_UPDATE_CYCLE_STRATEGY = "update_cycle_strategy"
+SERVICE_SET_CYCLE_DAY_SCHEDULE = "set_cycle_day_schedule"
+SERVICE_FORCE_CHARGE = "force_charge"
+SERVICE_STOP_FORCE_CHARGE = "stop_force_charge"
 
 # Service attributes
 ATTR_END_DISCHARGE = "end_discharge"
@@ -84,9 +104,68 @@ SENSOR_SELF_SUFFICIENCY = "self_sufficiency"
 SENSOR_TREES_PLANTED = "trees_planted"
 SENSOR_CO2_REDUCTION = "co2_reduction_tons"
 
+# Additional read-only telemetry discovered in live cloud API
+SENSOR_PV_POWER_L1 = "pv_power_l1"
+SENSOR_PV_POWER_L2 = "pv_power_l2"
+SENSOR_PV_POWER_L3 = "pv_power_l3"
+SENSOR_PV_POWER_L4 = "pv_power_l4"
+SENSOR_REAL_POWER_L1 = "real_power_l1"
+SENSOR_REAL_POWER_L2 = "real_power_l2"
+SENSOR_REAL_POWER_L3 = "real_power_l3"
+SENSOR_METER_DC_POWER = "meter_dc_power"
+SENSOR_EV_POWER = "ev_power"
+SENSOR_UPS_MODEL = "ups_model"
+SENSOR_HAS_SECONDARY_DATA = "has_secondary_data"
+SENSOR_DATA_TYPE = "data_type"
+SENSOR_FORCE_CHARGE_MODE = "force_charge_mode"
+SENSOR_INVERTER_MODE = "inverter_mode"
+SENSOR_HAS_GENERATOR = "has_generator"
+SENSOR_HAS_CHARGING_PILE = "has_charging_pile"
+SENSOR_GRID_DISCHARGE_TOTAL = "grid_discharge_total"
+SENSOR_BATTERY_TO_LOAD_TOTAL = "battery_to_load_total"
+SENSOR_EV_CHARGING_TOTAL = "ev_charging_total"
+SENSOR_GRID_TO_LOAD_TOTAL = "grid_to_load_total"
+SENSOR_DIESEL_ENERGY_TOTAL = "diesel_energy_total"
+SENSOR_CONTROL_VARIANT = "control_variant"
+SENSOR_DETECTED_CONTROL_VARIANT = "detected_control_variant"
+SENSOR_CONTROL_VARIANT_SOURCE = "control_variant_source"
+SENSOR_CONTROL_SYSTEM_ID = "control_system_id"
+SENSOR_CONTROL_SUMMARY = "control_summary"
+SENSOR_FORCE_CHARGE_LIMIT = "force_charge_limit"
+SENSOR_FORCE_CHARGE_STATUS = "force_charge_status"
+SENSOR_CYCLE_CHARGE_ACTIVE = "cycle_charge_active"
+SENSOR_CYCLE_DISCHARGE_ACTIVE = "cycle_discharge_active"
+SENSOR_CYCLE_CHARGE_COUNT = "cycle_charge_count"
+SENSOR_CYCLE_DISCHARGE_COUNT = "cycle_discharge_count"
+SENSOR_CYCLE_CHARGE_START = "cycle_charge_start"
+SENSOR_CYCLE_CHARGE_END = "cycle_charge_end"
+SENSOR_CYCLE_DISCHARGE_START = "cycle_discharge_start"
+SENSOR_CYCLE_DISCHARGE_END = "cycle_discharge_end"
+SENSOR_CYCLE_CHARGE_WINDOWS_JSON = "cycle_charge_windows_json"
+SENSOR_CYCLE_DISCHARGE_WINDOWS_JSON = "cycle_discharge_windows_json"
+
 # Circuit breaker and connection constants
 MAX_DIAGNOSTIC_LOGS = 100
 RECENT_DATA_THRESHOLD = 300  # 5 minutes in seconds
 STALE_DATA_THRESHOLD = 3600  # 1 hour in seconds
 AUTO_RECONNECT_INTERVAL_HOURS = 24  # 24 hours
 HTTPS_PORT = 443
+
+# Per-inverter sensor types
+SENSOR_INVERTER_252_PV_POWER = "inverter_252_pv_power"
+SENSOR_INVERTER_252_BATTERY_POWER = "inverter_252_battery_power"
+SENSOR_INVERTER_252_GRID_POWER = "inverter_252_grid_power"
+SENSOR_INVERTER_252_LOAD_POWER = "inverter_252_load_power"
+SENSOR_INVERTER_252_SOC = "inverter_252_soc"
+
+SENSOR_INVERTER_253_PV_POWER = "inverter_253_pv_power"
+SENSOR_INVERTER_253_BATTERY_POWER = "inverter_253_battery_power"
+SENSOR_INVERTER_253_GRID_POWER = "inverter_253_grid_power"
+SENSOR_INVERTER_253_LOAD_POWER = "inverter_253_load_power"
+SENSOR_INVERTER_253_SOC = "inverter_253_soc"
+
+# Known inverter serial numbers
+KNOWN_INVERTER_SNS = [
+    "25000SP2B5W00252",
+    "25000SP2B5W00253"
+]

--- a/custom_components/bytewatt/coordinator.py
+++ b/custom_components/bytewatt/coordinator.py
@@ -19,18 +19,22 @@ from homeassistant.util import dt as dt_util
 from .bytewatt_client import ByteWattClient
 from .const import (
     DOMAIN,
+    CONF_CONTROL_VARIANT,
+    CONF_CONTROL_TARGET_SYSTEM_ID,
     CONF_HEARTBEAT_INTERVAL,
     CONF_MAX_DATA_AGE,
     CONF_STALE_CHECKS_THRESHOLD,
     CONF_NOTIFY_ON_RECOVERY,
     CONF_DIAGNOSTICS_MODE,
     CONF_AUTO_RECONNECT_TIME,
+    CONF_INVERTER_SNS,
     DEFAULT_HEARTBEAT_INTERVAL,
     DEFAULT_MAX_DATA_AGE,
     DEFAULT_STALE_CHECKS_THRESHOLD,
     DEFAULT_NOTIFY_ON_RECOVERY,
     DEFAULT_DIAGNOSTICS_MODE,
     DEFAULT_AUTO_RECONNECT_TIME,
+    DEFAULT_INVERTER_SNS,
     MAX_DIAGNOSTIC_LOGS,
     RECENT_DATA_THRESHOLD,
     STALE_DATA_THRESHOLD,
@@ -73,6 +77,11 @@ class ByteWattDataUpdateCoordinator(DataUpdateCoordinator):
         self._auto_reconnect_unsub = None
         self._webhook_id = None
         self._webhook_unsub = None
+        self._inverter_list = []  # Store discovered inverters
+        self._configured_control_variant = options.get(CONF_CONTROL_VARIANT, "auto")
+        self._configured_control_target_system_id = options.get(CONF_CONTROL_TARGET_SYSTEM_ID, "")
+        self._control_variant_info: Dict[str, Any] = {}
+        self._last_force_charge_diagnostics: Dict[str, Any] = {}
         
         # Connection health tracking
         self.circuit_breaker = CircuitBreaker()
@@ -177,18 +186,57 @@ class ByteWattDataUpdateCoordinator(DataUpdateCoordinator):
                     await self.client.api_client.async_get_battery_settings()
             except Exception as ex:
                 _LOGGER.warning(f"Failed to fetch battery settings: {ex}")
+
+            # Detect active control variant and collect control metadata.
+            try:
+                self._control_variant_info = await self.client.api_client.async_detect_control_variant(
+                    self._configured_control_variant
+                )
+                if self._configured_control_target_system_id:
+                    self._control_variant_info["target_system_id"] = self._configured_control_target_system_id
+                    self._control_variant_info["target_selection_source"] = "user_config"
+                if self._last_force_charge_diagnostics:
+                    self._control_variant_info.update(self._last_force_charge_diagnostics)
+                _LOGGER.info(
+                    "ByteWatt control variant: detected=%s effective=%s target_system_id=%s target_sys_sn=%s source=%s",
+                    self._control_variant_info.get("detected_variant"),
+                    self._control_variant_info.get("effective_variant"),
+                    self._control_variant_info.get("target_system_id"),
+                    self._control_variant_info.get("target_sys_sn"),
+                    self._control_variant_info.get("target_selection_source") or self._control_variant_info.get("variant_source"),
+                )
+            except Exception as ex:
+                _LOGGER.warning(f"Failed to detect control variant: {ex}")
+                self._control_variant_info = {
+                    "configured_variant": self._configured_control_variant,
+                    "detected_variant": "unknown",
+                    "effective_variant": self._configured_control_variant,
+                    "variant_source": "detection_error",
+                    "target_system_id": self._configured_control_target_system_id or None,
+                    "summary": str(ex),
+                }
+                if self._last_force_charge_diagnostics:
+                    self._control_variant_info.update(self._last_force_charge_diagnostics)
             
             # If we got battery data, update our cached version and last successful time
             if battery_data:
-                self._last_battery_data = battery_data
-                self._last_successful_update = current_time
-                self._consecutive_stale_checks = 0
-                self._recovery_attempts = 0  # Reset recovery attempts on successful update
-                
-                self.diagnostic_service.log_diagnostic("data_update", {
-                    "type": "battery_data",
-                    "result": "success"
-                })
+                if self._is_all_zero_payload(battery_data) and self._last_battery_data:
+                    _LOGGER.warning("Received all-zero ByteWatt payload, preserving cached data")
+                    self.diagnostic_service.log_diagnostic("data_update", {
+                        "type": "battery_data",
+                        "result": "all_zero_payload_using_cache"
+                    })
+                    battery_data = None
+                else:
+                    self._last_battery_data = battery_data
+                    self._last_successful_update = current_time
+                    self._consecutive_stale_checks = 0
+                    self._recovery_attempts = 0  # Reset recovery attempts on successful update
+                    
+                    self.diagnostic_service.log_diagnostic("data_update", {
+                        "type": "battery_data",
+                        "result": "success"
+                    })
             elif self._last_battery_data is None:
                 # Only raise error if we never got data
                 error_msg = "Failed to get battery data and no cached data available"
@@ -217,8 +265,33 @@ class ByteWattDataUpdateCoordinator(DataUpdateCoordinator):
                 "battery": self._last_battery_data or {},
                 "connection_status": "connected" if battery_data else "partial",
                 "circuit_breaker": self.circuit_breaker.state.value,
-                "last_updated": current_time.isoformat()
+                "last_updated": current_time.isoformat(),
+                "control_variant": self._control_variant_info,
             }
+            
+            # Get per-inverter data if configured or auto-discovered
+            # This runs less frequently to avoid excessive API calls
+            per_inverter_data = None
+            try:
+                # Get inverter list and per-inverter power data
+                inverter_list = await self.client.api_client.async_get_inverter_list()
+                if inverter_list:
+                    # Store inverter list for sensor setup
+                    self._inverter_list = inverter_list
+                    
+                    # Get SNs for power data
+                    inverter_sns = [inv.get("sysSn") for inv in inverter_list if inv.get("sysSn")]
+                    
+                    # Get per-inverter power data
+                    per_inverter_data = await self.client.api_client.async_get_per_inverter_data(inverter_sns)
+                    
+                    if per_inverter_data:
+                        data["inverters"] = per_inverter_data
+                        data["inverter_list"] = inverter_list
+                        
+                        _LOGGER.debug("Added per-inverter data for %d inverters", len(per_inverter_data))
+            except Exception as ex:
+                _LOGGER.warning(f"Failed to fetch per-inverter data: {ex}")
             
             _LOGGER.debug(f"Coordinator data refreshed with keys: {list(data.keys())}")
             return data
@@ -268,6 +341,30 @@ class ByteWattDataUpdateCoordinator(DataUpdateCoordinator):
                         _LOGGER.error(f"Traceback: {traceback.format_exc()}")
                     
                 raise UpdateFailed(f"Error communicating with API: {err}")
+
+    def _is_all_zero_payload(self, battery_data: Dict[str, Any]) -> bool:
+        """Detect suspicious all-zero payloads that should not overwrite cached data."""
+        keys = [
+            "pgrid",
+            "pload",
+            "pbat",
+            "ppv",
+            "soc",
+            "Total_House_Consumption",
+            "Grid_Power_Consumption",
+            "PV_Generated_Today",
+            "Consumed_Today",
+        ]
+        values = []
+        for key in keys:
+            if key not in battery_data:
+                continue
+            value = battery_data.get(key)
+            try:
+                values.append(float(value))
+            except (TypeError, ValueError):
+                continue
+        return bool(values) and all(abs(value) < 1e-9 for value in values)
     
     async def start_heartbeat(self) -> None:
         """Start the heartbeat service to monitor and recover the integration."""

--- a/custom_components/bytewatt/manifest.json
+++ b/custom_components/bytewatt/manifest.json
@@ -1,12 +1,17 @@
 {
   "domain": "bytewatt",
   "name": "Byte-Watt Battery Monitor",
-  "codeowners": ["@candreacchio"],
+  "codeowners": [
+    "@candreacchio"
+  ],
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/candreacchio/neovoltBattery_HomeAssistantPlugin",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/candreacchio/neovoltBattery_HomeAssistantPlugin/issues",
-  "requirements": ["requests"],
-  "version": "1.0.0"
+  "requirements": [
+    "requests"
+  ],
+  "version": "1.0.0",
+  "icon": "mdi:battery-charging"
 }

--- a/custom_components/bytewatt/models.py
+++ b/custom_components/bytewatt/models.py
@@ -3,6 +3,21 @@ from dataclasses import dataclass, field
 from typing import Dict, Any, Optional, List
 
 
+def detect_control_variant_from_settings(data: Dict[str, Any]) -> str:
+    """Infer the active control variant from a charge-config payload."""
+    if not isinstance(data, dict):
+        return "unknown"
+
+    # Legacy/simple model: direct windows and flags in getChargeConfigInfo.
+    # Cycle-strategy model is usually indicated by richer strategy-only fields,
+    # but for charge-config payload alone we treat it as charge_config unless
+    # proven otherwise by dedicated cycle strategy data.
+    if any(key in data for key in ["gridCharge", "ctrDis", "timeChaf1", "timeDisf1"]):
+        return "charge_config"
+
+    return "unknown"
+
+
 @dataclass
 class SoCData:
     """Represents battery State of Charge data."""
@@ -102,6 +117,7 @@ class BatterySettings:
     
     # Additional fields
     additional_fields: Dict[str, Any] = field(default_factory=dict)
+    control_variant: str = "charge_config"
     
     @classmethod
     def from_api_response(cls, data: Dict[str, Any]) -> "BatterySettings":
@@ -139,6 +155,7 @@ class BatterySettings:
             pm_offset_e1a=data.get("pm_offset_e1a", "00:00"),
             pm_offset_s2a=data.get("pm_offset_s2a", "00:00"),
             pm_offset_e2a=data.get("pm_offset_e2a", "00:00"),
+            control_variant=detect_control_variant_from_settings(data),
         )
         
         # Store additional fields
@@ -177,9 +194,9 @@ class BatterySettings:
         """Convert settings to dictionary for API submissions using new API format."""
         result = {
             "id": "",  # Empty for all devices
-            "basicModeJp": None,
-            "peaceModeJp": None,
-            "vppModeJp": None,
+            "basicModeJp": self.additional_fields.get("basicModeJp"),
+            "peaceModeJp": self.additional_fields.get("peaceModeJp"),
+            "vppModeJp": self.additional_fields.get("vppModeJp"),
             "gridCharge": self.grid_charge,
             "timeChaf1": self.time_chaf1a,
             "timeChae1": self.time_chae1a,
@@ -192,22 +209,22 @@ class BatterySettings:
             "timeDise2": self.time_dise2a,
             "batHighCap": float(self.bat_high_cap) if isinstance(self.bat_high_cap, str) else self.bat_high_cap,
             "batUseCap": self.bat_use_cap,
-            "batCapRange": [5, 100],  # Default range
+            "batCapRange": self.additional_fields.get("batCapRange", [5, 100]),
             "isJapaneseDevice": False,
-            "upsReserveEnable": True,
-            "upsReserve": 1,
-            "mbat": "BW-BAT-10.1P",  # Default battery model
-            "chargeModeSetting": 0,
-            "loadcutoutEn": 0,
-            "cutoffSoc": 0,
-            "wakeupSoc": 0,
-            "timeChaMode": 0,
-            "hasBalconyModel": 0,
-            "balconyModel": None,
-            "timeExpLimW1": 800,
-            "timeExpLimW2": 800,
-            "isSiteDevice": None,
-            "isSupportOffGridSocControl": True,
+            "upsReserveEnable": self.additional_fields.get("upsReserveEnable", True),
+            "upsReserve": self.additional_fields.get("upsReserve", 1),
+            "mbat": self.additional_fields.get("mbat", "BW-BAT-10.1P"),
+            "chargeModeSetting": self.additional_fields.get("chargeModeSetting", 0),
+            "loadcutoutEn": self.additional_fields.get("loadcutoutEn", 0),
+            "cutoffSoc": self.additional_fields.get("cutoffSoc", 0),
+            "wakeupSoc": self.additional_fields.get("wakeupSoc", 0),
+            "timeChaMode": self.additional_fields.get("timeChaMode", 0),
+            "hasBalconyModel": self.additional_fields.get("hasBalconyModel", 0),
+            "balconyModel": self.additional_fields.get("balconyModel"),
+            "timeExpLimW1": self.additional_fields.get("timeExpLimW1", 800),
+            "timeExpLimW2": self.additional_fields.get("timeExpLimW2", 800),
+            "isSiteDevice": self.additional_fields.get("isSiteDevice"),
+            "isSupportOffGridSocControl": self.additional_fields.get("isSupportOffGridSocControl", True),
         }
         
         # Add additional fields

--- a/custom_components/bytewatt/number.py
+++ b/custom_components/bytewatt/number.py
@@ -26,6 +26,10 @@ async def async_setup_entry(
     entities = [
         ByteWattChargeCapNumber(coordinator, config_entry),
         ByteWattMinimumSOCNumber(coordinator, config_entry),
+        ByteWattUPSReserveNumber(coordinator, config_entry),
+        ByteWattChargeModeSettingNumber(coordinator, config_entry),
+        ByteWattExportLimitWindow1Number(coordinator, config_entry),
+        ByteWattExportLimitWindow2Number(coordinator, config_entry),
     ]
 
     async_add_entities(entities)
@@ -68,6 +72,27 @@ class ByteWattNumberEntity(CoordinatorEntity, NumberEntity):
             "model": "Battery Management System",
             "sw_version": "1.0.0",
         }
+
+    def _effective_control_variant(self) -> Optional[str]:
+        """Return the currently effective control variant."""
+        try:
+            control_data = (self.coordinator.data or {}).get("control_variant", {})
+            return control_data.get("effective_variant")
+        except Exception:
+            return None
+
+    @property
+    def available(self) -> bool:
+        """Only expose legacy number controls for legacy charge-config systems."""
+        try:
+            client = self.hass.data[DOMAIN][self._config_entry.entry_id]["client"]
+            has_cache = hasattr(client.api_client, "_settings_cache") and client.api_client._settings_cache is not None
+        except Exception:
+            has_cache = False
+        variant = self._effective_control_variant()
+        if variant and variant != "charge_config":
+            return False
+        return has_cache
 
 
 class ByteWattMinimumSOCNumber(ByteWattNumberEntity):
@@ -163,3 +188,160 @@ class ByteWattChargeCapNumber(ByteWattNumberEntity):
                 _LOGGER.error(f"Failed to update charge cap to {value}%")
         except Exception as ex:
             _LOGGER.error(f"Error setting charge cap to {value}%: {ex}")
+
+
+class ByteWattUPSReserveNumber(ByteWattNumberEntity):
+    """Number entity for UPS reserve."""
+
+    def __init__(self, coordinator: ByteWattDataUpdateCoordinator, config_entry: ConfigEntry) -> None:
+        super().__init__(
+            coordinator=coordinator,
+            config_entry=config_entry,
+            name="UPS Reserve",
+            unique_id="ups_reserve",
+            icon="mdi:battery-lock",
+            min_value=0,
+            max_value=100,
+            step=1,
+            device_class=NumberDeviceClass.BATTERY,
+        )
+        self._attr_native_unit_of_measurement = "%"
+
+    @property
+    def native_value(self) -> Optional[float]:
+        try:
+            client = self.hass.data[DOMAIN][self._config_entry.entry_id]["client"]
+            if hasattr(client.api_client, "_settings_cache") and client.api_client._settings_cache:
+                settings = client.api_client._settings_cache
+                return float(settings.additional_fields.get("upsReserve", 0))
+        except (ValueError, TypeError, AttributeError) as ex:
+            _LOGGER.debug(f"Error getting UPS reserve: {ex}")
+        return None
+
+    async def async_set_native_value(self, value: float) -> None:
+        try:
+            client = self.hass.data[DOMAIN][self._config_entry.entry_id]["client"]
+            success = await client.update_battery_settings(ups_reserve=int(value))
+            if success:
+                if hasattr(client.api_client, "_settings_cache") and client.api_client._settings_cache:
+                    client.api_client._settings_cache.additional_fields["upsReserve"] = int(value)
+                await self.coordinator.async_request_refresh()
+        except Exception as ex:
+            _LOGGER.error(f"Error setting UPS reserve to {value}%: {ex}")
+
+
+class ByteWattChargeModeSettingNumber(ByteWattNumberEntity):
+    """Number entity for charge mode setting."""
+
+    def __init__(self, coordinator: ByteWattDataUpdateCoordinator, config_entry: ConfigEntry) -> None:
+        super().__init__(
+            coordinator=coordinator,
+            config_entry=config_entry,
+            name="Charge Mode Setting",
+            unique_id="charge_mode_setting",
+            icon="mdi:tune-variant",
+            min_value=0,
+            max_value=5,
+            step=1,
+        )
+
+    @property
+    def native_value(self) -> Optional[float]:
+        try:
+            client = self.hass.data[DOMAIN][self._config_entry.entry_id]["client"]
+            if hasattr(client.api_client, "_settings_cache") and client.api_client._settings_cache:
+                settings = client.api_client._settings_cache
+                raw = settings.additional_fields.get("chargeModeSetting", 0)
+                return float(raw)
+        except (ValueError, TypeError, AttributeError) as ex:
+            _LOGGER.debug(f"Error getting charge mode setting: {ex}")
+        return None
+
+    async def async_set_native_value(self, value: float) -> None:
+        try:
+            client = self.hass.data[DOMAIN][self._config_entry.entry_id]["client"]
+            success = await client.update_battery_settings(charge_mode_setting=int(value))
+            if success:
+                if hasattr(client.api_client, "_settings_cache") and client.api_client._settings_cache:
+                    client.api_client._settings_cache.additional_fields["chargeModeSetting"] = int(value)
+                await self.coordinator.async_request_refresh()
+        except Exception as ex:
+            _LOGGER.error(f"Error setting charge mode setting to {value}: {ex}")
+
+
+class ByteWattExportLimitWindow1Number(ByteWattNumberEntity):
+    """Number entity for export limit window 1."""
+
+    def __init__(self, coordinator: ByteWattDataUpdateCoordinator, config_entry: ConfigEntry) -> None:
+        super().__init__(
+            coordinator=coordinator,
+            config_entry=config_entry,
+            name="Export Limit Window 1",
+            unique_id="export_limit_window_1",
+            icon="mdi:transmission-tower-export",
+            min_value=0,
+            max_value=20000,
+            step=50,
+        )
+        self._attr_native_unit_of_measurement = "W"
+
+    @property
+    def native_value(self) -> Optional[float]:
+        try:
+            client = self.hass.data[DOMAIN][self._config_entry.entry_id]["client"]
+            if hasattr(client.api_client, "_settings_cache") and client.api_client._settings_cache:
+                settings = client.api_client._settings_cache
+                return float(settings.additional_fields.get("timeExpLimW1", 800))
+        except (ValueError, TypeError, AttributeError) as ex:
+            _LOGGER.debug(f"Error getting export limit window 1: {ex}")
+        return None
+
+    async def async_set_native_value(self, value: float) -> None:
+        try:
+            client = self.hass.data[DOMAIN][self._config_entry.entry_id]["client"]
+            success = await client.update_battery_settings(export_limit_w1=int(value))
+            if success:
+                if hasattr(client.api_client, "_settings_cache") and client.api_client._settings_cache:
+                    client.api_client._settings_cache.additional_fields["timeExpLimW1"] = int(value)
+                await self.coordinator.async_request_refresh()
+        except Exception as ex:
+            _LOGGER.error(f"Error setting export limit window 1 to {value}: {ex}")
+
+
+class ByteWattExportLimitWindow2Number(ByteWattNumberEntity):
+    """Number entity for export limit window 2."""
+
+    def __init__(self, coordinator: ByteWattDataUpdateCoordinator, config_entry: ConfigEntry) -> None:
+        super().__init__(
+            coordinator=coordinator,
+            config_entry=config_entry,
+            name="Export Limit Window 2",
+            unique_id="export_limit_window_2",
+            icon="mdi:transmission-tower-export",
+            min_value=0,
+            max_value=20000,
+            step=50,
+        )
+        self._attr_native_unit_of_measurement = "W"
+
+    @property
+    def native_value(self) -> Optional[float]:
+        try:
+            client = self.hass.data[DOMAIN][self._config_entry.entry_id]["client"]
+            if hasattr(client.api_client, "_settings_cache") and client.api_client._settings_cache:
+                settings = client.api_client._settings_cache
+                return float(settings.additional_fields.get("timeExpLimW2", 800))
+        except (ValueError, TypeError, AttributeError) as ex:
+            _LOGGER.debug(f"Error getting export limit window 2: {ex}")
+        return None
+
+    async def async_set_native_value(self, value: float) -> None:
+        try:
+            client = self.hass.data[DOMAIN][self._config_entry.entry_id]["client"]
+            success = await client.update_battery_settings(export_limit_w2=int(value))
+            if success:
+                if hasattr(client.api_client, "_settings_cache") and client.api_client._settings_cache:
+                    client.api_client._settings_cache.additional_fields["timeExpLimW2"] = int(value)
+                await self.coordinator.async_request_refresh()
+        except Exception as ex:
+            _LOGGER.error(f"Error setting export limit window 2 to {value}: {ex}")

--- a/custom_components/bytewatt/sensor.py
+++ b/custom_components/bytewatt/sensor.py
@@ -1,7 +1,6 @@
 """Sensor platform for Byte-Watt integration."""
 import logging
-from typing import Callable, Dict, Optional, Any
-from datetime import datetime
+from typing import Optional
 
 from homeassistant.components.sensor import SensorEntity, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
@@ -40,6 +39,44 @@ from .const import (
     SENSOR_TREES_PLANTED,
     SENSOR_CO2_REDUCTION,
     SENSOR_TOTAL_BATTERY_DISCHARGE,
+    SENSOR_PV_POWER_L1,
+    SENSOR_PV_POWER_L2,
+    SENSOR_PV_POWER_L3,
+    SENSOR_PV_POWER_L4,
+    SENSOR_REAL_POWER_L1,
+    SENSOR_REAL_POWER_L2,
+    SENSOR_REAL_POWER_L3,
+    SENSOR_METER_DC_POWER,
+    SENSOR_EV_POWER,
+    SENSOR_UPS_MODEL,
+    SENSOR_HAS_SECONDARY_DATA,
+    SENSOR_DATA_TYPE,
+    SENSOR_FORCE_CHARGE_MODE,
+    SENSOR_INVERTER_MODE,
+    SENSOR_HAS_GENERATOR,
+    SENSOR_HAS_CHARGING_PILE,
+    SENSOR_GRID_DISCHARGE_TOTAL,
+    SENSOR_BATTERY_TO_LOAD_TOTAL,
+    SENSOR_EV_CHARGING_TOTAL,
+    SENSOR_GRID_TO_LOAD_TOTAL,
+    SENSOR_DIESEL_ENERGY_TOTAL,
+    SENSOR_CONTROL_VARIANT,
+    SENSOR_DETECTED_CONTROL_VARIANT,
+    SENSOR_CONTROL_VARIANT_SOURCE,
+    SENSOR_CONTROL_SYSTEM_ID,
+    SENSOR_CONTROL_SUMMARY,
+    SENSOR_FORCE_CHARGE_LIMIT,
+    SENSOR_FORCE_CHARGE_STATUS,
+    SENSOR_CYCLE_CHARGE_ACTIVE,
+    SENSOR_CYCLE_DISCHARGE_ACTIVE,
+    SENSOR_CYCLE_CHARGE_COUNT,
+    SENSOR_CYCLE_DISCHARGE_COUNT,
+    SENSOR_CYCLE_CHARGE_START,
+    SENSOR_CYCLE_CHARGE_END,
+    SENSOR_CYCLE_DISCHARGE_START,
+    SENSOR_CYCLE_DISCHARGE_END,
+    SENSOR_CYCLE_CHARGE_WINDOWS_JSON,
+    SENSOR_CYCLE_DISCHARGE_WINDOWS_JSON,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -113,6 +150,270 @@ async def async_setup_entry(
             "", 
             "mdi:clock-outline",
             entity_category=EntityCategory.DIAGNOSTIC
+        ),
+        ByteWattSensor(
+            coordinator,
+            entry,
+            SENSOR_PV_POWER_L1,
+            "PV Power L1",
+            "power",
+            "ppv1",
+            "W",
+            "mdi:solar-power-variant"
+        ),
+        ByteWattSensor(
+            coordinator,
+            entry,
+            SENSOR_PV_POWER_L2,
+            "PV Power L2",
+            "power",
+            "ppv2",
+            "W",
+            "mdi:solar-power-variant"
+        ),
+        ByteWattSensor(
+            coordinator,
+            entry,
+            SENSOR_PV_POWER_L3,
+            "PV Power L3",
+            "power",
+            "ppv3",
+            "W",
+            "mdi:solar-power-variant"
+        ),
+        ByteWattSensor(
+            coordinator,
+            entry,
+            SENSOR_PV_POWER_L4,
+            "PV Power L4",
+            "power",
+            "ppv4",
+            "W",
+            "mdi:solar-power-variant"
+        ),
+        ByteWattSensor(
+            coordinator,
+            entry,
+            SENSOR_REAL_POWER_L1,
+            "Real Power L1",
+            "power",
+            "prealL1",
+            "W",
+            "mdi:sine-wave"
+        ),
+        ByteWattSensor(
+            coordinator,
+            entry,
+            SENSOR_REAL_POWER_L2,
+            "Real Power L2",
+            "power",
+            "prealL2",
+            "W",
+            "mdi:sine-wave"
+        ),
+        ByteWattSensor(
+            coordinator,
+            entry,
+            SENSOR_REAL_POWER_L3,
+            "Real Power L3",
+            "power",
+            "prealL3",
+            "W",
+            "mdi:sine-wave"
+        ),
+        ByteWattSensor(
+            coordinator,
+            entry,
+            SENSOR_METER_DC_POWER,
+            "Meter DC Power",
+            "power",
+            "pmeterDc",
+            "W",
+            "mdi:meter-electric-outline"
+        ),
+        ByteWattSensor(
+            coordinator,
+            entry,
+            SENSOR_EV_POWER,
+            "EV Power",
+            "power",
+            "pev",
+            "W",
+            "mdi:car-electric"
+        ),
+        ByteWattSensor(
+            coordinator,
+            entry,
+            SENSOR_UPS_MODEL,
+            "UPS Model",
+            None,
+            "upsModel",
+            "",
+            "mdi:battery-lock"
+        ),
+        ByteWattSensor(
+            coordinator,
+            entry,
+            SENSOR_HAS_SECONDARY_DATA,
+            "Has Secondary Data",
+            None,
+            "hasSecData",
+            "",
+            "mdi:database-check-outline",
+            entity_category=EntityCategory.DIAGNOSTIC
+        ),
+        ByteWattSensor(
+            coordinator,
+            entry,
+            SENSOR_DATA_TYPE,
+            "Data Type",
+            None,
+            "dataType",
+            "",
+            "mdi:identifier",
+            entity_category=EntityCategory.DIAGNOSTIC
+        ),
+        ByteWattSensor(
+            coordinator,
+            entry,
+            SENSOR_FORCE_CHARGE_MODE,
+            "Force Charge Mode",
+            None,
+            "forceChargeMode",
+            "",
+            "mdi:battery-plus-variant",
+            entity_category=EntityCategory.DIAGNOSTIC
+        ),
+        ByteWattSensor(
+            coordinator,
+            entry,
+            SENSOR_INVERTER_MODE,
+            "Inverter Mode",
+            None,
+            "inverterMode",
+            "",
+            "mdi:power-settings",
+            entity_category=EntityCategory.DIAGNOSTIC
+        ),
+        ByteWattControlVariantSensor(
+            coordinator,
+            entry,
+            SENSOR_CONTROL_VARIANT,
+            "Control Variant",
+            "effective_variant",
+        ),
+        ByteWattControlVariantSensor(
+            coordinator,
+            entry,
+            SENSOR_DETECTED_CONTROL_VARIANT,
+            "Detected Control Variant",
+            "detected_variant",
+        ),
+        ByteWattControlVariantSensor(
+            coordinator,
+            entry,
+            SENSOR_CONTROL_VARIANT_SOURCE,
+            "Control Variant Source",
+            "variant_source",
+        ),
+        ByteWattControlVariantSensor(
+            coordinator,
+            entry,
+            SENSOR_CONTROL_SYSTEM_ID,
+            "Control System ID",
+            "system_id",
+        ),
+        ByteWattControlVariantSensor(
+            coordinator,
+            entry,
+            SENSOR_CONTROL_SUMMARY,
+            "Control Summary",
+            "summary",
+        ),
+        ByteWattControlVariantSensor(
+            coordinator,
+            entry,
+            SENSOR_FORCE_CHARGE_LIMIT,
+            "Force Charge Limit",
+            "force_charge_limit",
+            unit="%",
+        ),
+        ByteWattControlVariantSensor(
+            coordinator,
+            entry,
+            SENSOR_FORCE_CHARGE_STATUS,
+            "Force Charge Status",
+            "force_charge_status",
+        ),
+        ByteWattControlVariantSensor(
+            coordinator,
+            entry,
+            SENSOR_CYCLE_CHARGE_ACTIVE,
+            "Cycle Charge Active",
+            "cycle_charge_active",
+        ),
+        ByteWattControlVariantSensor(
+            coordinator,
+            entry,
+            SENSOR_CYCLE_DISCHARGE_ACTIVE,
+            "Cycle Discharge Active",
+            "cycle_discharge_active",
+        ),
+        ByteWattControlVariantSensor(
+            coordinator,
+            entry,
+            SENSOR_CYCLE_CHARGE_COUNT,
+            "Cycle Charge Count",
+            "cycle_charge_count",
+        ),
+        ByteWattControlVariantSensor(
+            coordinator,
+            entry,
+            SENSOR_CYCLE_DISCHARGE_COUNT,
+            "Cycle Discharge Count",
+            "cycle_discharge_count",
+        ),
+        ByteWattControlVariantSensor(
+            coordinator,
+            entry,
+            SENSOR_CYCLE_CHARGE_START,
+            "Cycle Charge Start",
+            "cycle_charge_start",
+        ),
+        ByteWattControlVariantSensor(
+            coordinator,
+            entry,
+            SENSOR_CYCLE_CHARGE_END,
+            "Cycle Charge End",
+            "cycle_charge_end",
+        ),
+        ByteWattControlVariantSensor(
+            coordinator,
+            entry,
+            SENSOR_CYCLE_DISCHARGE_START,
+            "Cycle Discharge Start",
+            "cycle_discharge_start",
+        ),
+        ByteWattControlVariantSensor(
+            coordinator,
+            entry,
+            SENSOR_CYCLE_DISCHARGE_END,
+            "Cycle Discharge End",
+            "cycle_discharge_end",
+        ),
+        ByteWattControlVariantSensor(
+            coordinator,
+            entry,
+            SENSOR_CYCLE_CHARGE_WINDOWS_JSON,
+            "Cycle Charge Windows JSON",
+            "cycle_charge_windows_json",
+        ),
+        ByteWattControlVariantSensor(
+            coordinator,
+            entry,
+            SENSOR_CYCLE_DISCHARGE_WINDOWS_JSON,
+            "Cycle Discharge Windows JSON",
+            "cycle_discharge_windows_json",
         ),
     ]
     
@@ -313,9 +614,169 @@ async def async_setup_entry(
             "tons", 
             "mdi:molecule-co2"
         ),
+        ByteWattSensor(
+            coordinator,
+            entry,
+            SENSOR_HAS_GENERATOR,
+            "Has Generator",
+            "",
+            "hasGenerator",
+            "",
+            "mdi:generator-portable",
+            entity_category=EntityCategory.DIAGNOSTIC
+        ),
+        ByteWattSensor(
+            coordinator,
+            entry,
+            SENSOR_HAS_CHARGING_PILE,
+            "Has Charging Pile",
+            "",
+            "hasChargingPile",
+            "",
+            "mdi:ev-station",
+            entity_category=EntityCategory.DIAGNOSTIC
+        ),
+        ByteWattGridSensor(
+            coordinator,
+            entry,
+            SENSOR_GRID_DISCHARGE_TOTAL,
+            "Grid Discharge Total",
+            "energy",
+            "egriddischarge",
+            "kWh",
+            "mdi:transmission-tower-export"
+        ),
+        ByteWattGridSensor(
+            coordinator,
+            entry,
+            SENSOR_BATTERY_TO_LOAD_TOTAL,
+            "Battery To Load Total",
+            "energy",
+            "batLoad",
+            "kWh",
+            "mdi:battery-arrow-down-outline"
+        ),
+        ByteWattGridSensor(
+            coordinator,
+            entry,
+            SENSOR_EV_CHARGING_TOTAL,
+            "EV Charging Total",
+            "energy",
+            "echargingPile",
+            "kWh",
+            "mdi:car-electric"
+        ),
+        ByteWattGridSensor(
+            coordinator,
+            entry,
+            SENSOR_GRID_TO_LOAD_TOTAL,
+            "Grid To Load Total",
+            "energy",
+            "egrid2Load",
+            "kWh",
+            "mdi:home-import-outline"
+        ),
+        ByteWattGridSensor(
+            coordinator,
+            entry,
+            SENSOR_DIESEL_ENERGY_TOTAL,
+            "Diesel Energy Total",
+            "energy",
+            "ediesel",
+            "kWh",
+            "mdi:fuel"
+        ),
     ]
     
-    async_add_entities(soc_sensors + grid_sensors + daily_stats_sensors)
+    # Add dynamic inverter sensors based on discovered inverters
+    # These will be created based on whatever inverters the API returns
+    inverter_sensors = []
+    
+    # Power/status sensors for each inverter (from getLastPowerData API)
+    inverter_power_attrs = [
+        ("pv_power", "PV Power", "power", "ppv", "W", "mdi:solar-power"),
+        ("battery_power", "Battery Power", "power", "pbat", "W", "mdi:battery-charging"),
+        ("grid_power", "Grid Power", "power", "pgrid", "W", "mdi:transmission-tower"),
+        ("house_power", "House Power", "power", "pload", "W", "mdi:home-lightning-bolt"),
+        ("soc", "Battery SOC", "battery", "soc", "%", "mdi:battery"),
+        ("pv_power_l1", "PV Power L1", "power", "ppv1", "W", "mdi:solar-power-variant"),
+        ("pv_power_l2", "PV Power L2", "power", "ppv2", "W", "mdi:solar-power-variant"),
+        ("pv_power_l3", "PV Power L3", "power", "ppv3", "W", "mdi:solar-power-variant"),
+        ("pv_power_l4", "PV Power L4", "power", "ppv4", "W", "mdi:solar-power-variant"),
+        ("real_power_l1", "Real Power L1", "power", "prealL1", "W", "mdi:transmission-tower-export"),
+        ("real_power_l2", "Real Power L2", "power", "prealL2", "W", "mdi:transmission-tower-export"),
+        ("real_power_l3", "Real Power L3", "power", "prealL3", "W", "mdi:transmission-tower-export"),
+        ("force_charge_mode", "Force Charge Mode", None, "forceChargeMode", None, "mdi:battery-plus"),
+        ("inverter_mode", "Inverter Mode", None, "inverterMode", None, "mdi:state-machine"),
+    ]
+    
+    # Info sensors for each inverter (from getCustomMenuEssList API)
+    inverter_info_attrs = [
+        ("pv_capacity", "PV Capacity", None, "popv", "kWp", "mdi:solar-panel"),
+        ("battery_capacity", "Battery Capacity", None, "cobat", "kWh", "mdi:battery"),
+        ("on_grid_cap", "On-Grid Cap", None, "onGridCap", "kW", "mdi:transmission-tower"),
+    ]
+    
+    # Try to get the inverter list from coordinator data if available
+    # Otherwise, we'll create sensors that will be available once data is fetched
+    inverter_list = []
+    if coordinator.data and "inverter_list" in coordinator.data:
+        inverter_list = coordinator.data.get("inverter_list", [])
+    
+    # If we don't have inverter data yet, create sensors with default inverter SNs
+    # that will become available once the coordinator fetches the data
+    if not inverter_list:
+        # Default fallback - sensors will show as unavailable until first data fetch
+        # The coordinator will populate inverter_list on its first successful update
+        inverter_list = [
+            {"sysSn": "25000SP2B5W00253"},
+            {"sysSn": "25000SP2B5W00252"},
+        ]
+        _LOGGER.info("No inverter data yet, creating placeholder sensors that will update when data is available")
+    
+    # Create sensors for each discovered inverter
+    for inverter in inverter_list:
+        inverter_sn = inverter.get("sysSn")
+        if not inverter_sn:
+            continue
+            
+        # Create power sensors for this inverter
+        for sensor_key, name, device_class, attr, unit, icon in inverter_power_attrs:
+            inverter_sensors.append(
+                ByteWattInverterSensor(
+                    coordinator,
+                    entry,
+                    inverter_sn,
+                    sensor_key,
+                    name,
+                    device_class,
+                    attr,
+                    unit,
+                    icon,
+                    None
+                )
+            )
+        
+        # Create info sensors for this inverter
+        for sensor_key, name, device_class, attr, unit, icon in inverter_info_attrs:
+            inverter_sensors.append(
+                ByteWattInverterInfoSensor(
+                    coordinator,
+                    entry,
+                    inverter_sn,
+                    sensor_key,
+                    name,
+                    device_class,
+                    attr,
+                    unit,
+                    icon,
+                    EntityCategory.DIAGNOSTIC
+                )
+            )
+    
+    _LOGGER.info(f"Created {len(inverter_sensors)} dynamic inverter sensors for {len(inverter_list)} inverters")
+    
+    async_add_entities(soc_sensors + grid_sensors + daily_stats_sensors + inverter_sensors)
 
 
 class ByteWattSensor(CoordinatorEntity, SensorEntity):
@@ -418,8 +879,20 @@ class ByteWattGridSensor(ByteWattSensor):
             icon,
             entity_category
         )
-        # Add state_class for energy sensors (kWh)
-        if unit == "kWh":
+        # Daily counters can reset at midnight, so they should not advertise
+        # total_increasing. Keep that only for true lifetime totals.
+        lifetime_total_attributes = {
+            "Total_Solar_Generation",
+            "Total_Feed_In",
+            "Total_Battery_Charge",
+            "Total_Battery_Discharge",
+            "PV_Power_House",
+            "PV_Charging_Battery",
+            "Total_House_Consumption",
+            "Grid_Based_Battery_Charge",
+            "Grid_Power_Consumption",
+        }
+        if unit == "kWh" and attribute in lifetime_total_attributes:
             self._attr_state_class = SensorStateClass.TOTAL_INCREASING
 
     @property
@@ -435,7 +908,15 @@ class ByteWattGridSensor(ByteWattSensor):
             
             # Handle special case for energy metrics which may be in a different format
             if self._attribute in battery_data:
-                return battery_data.get(self._attribute)
+                value = battery_data.get(self._attribute)
+                if value is None:
+                    return None
+                if self._attr_native_unit_of_measurement == "kWh":
+                    try:
+                        return float(value)
+                    except (ValueError, TypeError):
+                        return None
+                return value
             
             # If data isn't available, we'll log it at debug level
             _LOGGER.debug(f"Grid sensor {self._attribute} data not found in battery response")
@@ -499,3 +980,245 @@ class ByteWattLastUpdateSensor(ByteWattSensor):
         return hasattr(self.coordinator, '_last_successful_update') and self.coordinator._last_successful_update is not None
 
 
+class ByteWattControlVariantSensor(CoordinatorEntity, SensorEntity):
+    """Diagnostic sensor for Byte-Watt control variant metadata."""
+
+    def __init__(self, coordinator, config_entry, sensor_type, name, key, unit: str | None = None):
+        super().__init__(coordinator)
+        self._config_entry = config_entry
+        self._key = key
+        self._attr_name = name
+        self._attr_unique_id = f"{config_entry.entry_id}_{sensor_type}"
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        if unit is not None:
+            self._attr_native_unit_of_measurement = unit
+        self._attr_icon = "mdi:tune-variant"
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self._config_entry.entry_id)},
+            "name": "ByteWatt Battery System",
+            "manufacturer": "ByteWatt",
+            "model": "Battery Management System",
+            "sw_version": "1.0.0",
+        }
+
+    @property
+    def native_value(self):
+        control_data = (self.coordinator.data or {}).get("control_variant", {})
+        value = control_data.get(self._key)
+        if value is None:
+            cycle_strategy = control_data.get("cycle_strategy") or {}
+            if self._key == "cycle_charge_active":
+                value = bool((cycle_strategy.get("gridChargeCycle") or 0) == 1 and len(cycle_strategy.get("dayChargeTimeList") or []) > 0)
+            elif self._key == "cycle_discharge_active":
+                value = bool((cycle_strategy.get("ctrDisCycle") or 0) == 1 and len(cycle_strategy.get("dayDischargeTimeList") or []) > 0)
+            elif self._key == "cycle_charge_count":
+                value = len(cycle_strategy.get("dayChargeTimeList") or [])
+            elif self._key == "cycle_discharge_count":
+                value = len(cycle_strategy.get("dayDischargeTimeList") or [])
+            elif self._key == "cycle_charge_start":
+                first = (cycle_strategy.get("dayChargeTimeList") or [None])[0]
+                value = first.get("beginTime") if first else None
+            elif self._key == "cycle_charge_end":
+                first = (cycle_strategy.get("dayChargeTimeList") or [None])[0]
+                value = first.get("endTime") if first else None
+            elif self._key == "cycle_discharge_start":
+                first = (cycle_strategy.get("dayDischargeTimeList") or [None])[0]
+                value = first.get("beginTime") if first else None
+            elif self._key == "cycle_discharge_end":
+                first = (cycle_strategy.get("dayDischargeTimeList") or [None])[0]
+                value = first.get("endTime") if first else None
+            elif self._key == "cycle_charge_windows_json":
+                value = f"{len(cycle_strategy.get('dayChargeTimeList') or [])} windows"
+            elif self._key == "cycle_discharge_windows_json":
+                value = f"{len(cycle_strategy.get('dayDischargeTimeList') or [])} windows"
+        if value is None:
+            return None
+        return value
+
+    @property
+    def available(self) -> bool:
+        # Keep diagnostics available even if the latest refresh had partial data,
+        # so restored state can be replaced as soon as attributes arrive.
+        return self.coordinator.last_update_success or bool((self.coordinator.data or {}).get("control_variant"))
+
+    @property
+    def extra_state_attributes(self):
+        control_data = (self.coordinator.data or {}).get("control_variant", {})
+        attrs = {
+            "configured_variant": control_data.get("configured_variant"),
+            "detected_variant": control_data.get("detected_variant"),
+            "effective_variant": control_data.get("effective_variant"),
+            "variant_source": control_data.get("variant_source"),
+            "host_sys_sn": control_data.get("host_sys_sn"),
+            "target_system_id": control_data.get("target_system_id"),
+            "target_sys_sn": control_data.get("target_sys_sn"),
+            "target_selection_source": control_data.get("target_selection_source"),
+            "cycle_charge_active": control_data.get("cycle_charge_active"),
+            "cycle_discharge_active": control_data.get("cycle_discharge_active"),
+        }
+        cycle_strategy = control_data.get("cycle_strategy") or {}
+        if cycle_strategy:
+            attrs["executeCycleType"] = cycle_strategy.get("executeCycleType")
+            attrs["gridChargeCycle"] = cycle_strategy.get("gridChargeCycle")
+            attrs["ctrDisCycle"] = cycle_strategy.get("ctrDisCycle")
+            attrs["dayChargeTimeList_count"] = len(cycle_strategy.get("dayChargeTimeList") or [])
+            attrs["dayDischargeTimeList_count"] = len(cycle_strategy.get("dayDischargeTimeList") or [])
+            if self._key == "cycle_charge_windows_json":
+                attrs["windows"] = cycle_strategy.get("dayChargeTimeList") or []
+            if self._key == "cycle_discharge_windows_json":
+                attrs["windows"] = cycle_strategy.get("dayDischargeTimeList") or []
+        candidates = control_data.get("system_candidates") or []
+        if candidates:
+            attrs["system_candidates"] = candidates
+        if control_data.get("last_force_charge_action"):
+            attrs["last_force_charge_action"] = control_data.get("last_force_charge_action")
+            attrs["last_force_charge_requested_limit"] = control_data.get("last_force_charge_requested_limit")
+            attrs["last_force_charge_updated_at"] = control_data.get("last_force_charge_updated_at")
+            attrs["last_force_charge_results"] = control_data.get("last_force_charge_results")
+        return attrs
+
+
+class ByteWattInverterSensor(CoordinatorEntity, SensorEntity):
+    """Representation of a Byte-Watt Per-Inverter Sensor (dynamic)."""
+    
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        config_entry: ConfigEntry,
+        inverter_sn: str,
+        sensor_key: str,
+        name: str,
+        device_class: str,
+        attribute: str,
+        unit: str,
+        icon: str,
+        entity_category: str = None,
+    ):
+        """Initialize the inverter sensor."""
+        super().__init__(coordinator)
+        self._config_entry = config_entry
+        self._inverter_sn = inverter_sn
+        self._sensor_key = sensor_key
+        self._attr_name = f"{name} ({inverter_sn})"
+        self._attr_device_class = device_class
+        self._attr_native_unit_of_measurement = unit
+        self._attr_icon = icon
+        self._attribute = attribute
+        self._attr_entity_category = entity_category
+        
+        # Set unique_id - use the inverter SN directly
+        self._attr_unique_id = f"bytewatt_{sensor_key}_{inverter_sn}"
+        
+        # Set entity registry enabled
+        self._attr_entity_registry_enabled_default = True
+    
+    @property
+    def native_value(self):
+        """Return the state of the sensor."""
+        try:
+            if not self.coordinator.data or "inverters" not in self.coordinator.data:
+                return None
+            
+            inverters_data = self.coordinator.data.get("inverters", {})
+            inverter_data = inverters_data.get(self._inverter_sn, {})
+            
+            if not inverter_data:
+                return None
+            
+            value = inverter_data.get(self._attribute)
+            if value is None:
+                return None
+            
+            # Convert to float if needed
+            if self._attr_native_unit_of_measurement in ["W", "kWh", "%"]:
+                try:
+                    return float(value)
+                except (ValueError, TypeError):
+                    return None
+            
+            return value
+        except Exception as ex:
+            _LOGGER.error(f"Error getting inverter sensor state: {ex}")
+            return None
+            
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        if not self.coordinator.data or "inverters" not in self.coordinator.data:
+            return False
+        return self._inverter_sn in self.coordinator.data.get("inverters", {})
+
+
+class ByteWattInverterInfoSensor(CoordinatorEntity, SensorEntity):
+    """Representation of a Byte-Watt Per-Inverter Info Sensor (dynamic)."""
+    
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        config_entry: ConfigEntry,
+        inverter_sn: str,
+        sensor_key: str,
+        name: str,
+        device_class: str,
+        attribute: str,
+        unit: str,
+        icon: str,
+        entity_category: str = None,
+    ):
+        """Initialize the inverter info sensor."""
+        super().__init__(coordinator)
+        self._config_entry = config_entry
+        self._inverter_sn = inverter_sn
+        self._sensor_key = sensor_key
+        self._attr_name = f"{name} ({inverter_sn})"
+        self._attr_device_class = device_class
+        self._attr_native_unit_of_measurement = unit
+        self._attr_icon = icon
+        self._attribute = attribute
+        self._attr_entity_category = entity_category
+        
+        # Set unique_id - use the inverter SN directly
+        self._attr_unique_id = f"bytewatt_{sensor_key}_{inverter_sn}_info"
+        
+        # Set entity registry enabled
+        self._attr_entity_registry_enabled_default = True
+    
+    @property
+    def native_value(self):
+        """Return the state of the sensor."""
+        try:
+            if not self.coordinator.data or "inverter_list" not in self.coordinator.data:
+                return None
+            
+            inverter_list = self.coordinator.data.get("inverter_list", [])
+            
+            # Find the inverter in the list
+            for inv in inverter_list:
+                if inv.get("sysSn") == self._inverter_sn:
+                    value = inv.get(self._attribute)
+                    if value is None:
+                        return None
+                    
+                    # Convert to appropriate type
+                    if self._attr_native_unit_of_measurement in ["W", "kWh", "kWp", "%"]:
+                        try:
+                            return float(value)
+                        except (ValueError, TypeError):
+                            return None
+                    return value
+            
+            return None
+        except Exception as ex:
+            _LOGGER.error(f"Error getting inverter info sensor state: {ex}")
+            return None
+            
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        if not self.coordinator.data or "inverter_list" not in self.coordinator.data:
+            return False
+        inverter_list = self.coordinator.data.get("inverter_list", [])
+        return any(inv.get("sysSn") == self._inverter_sn for inv in inverter_list)

--- a/custom_components/bytewatt/services.yaml
+++ b/custom_components/bytewatt/services.yaml
@@ -43,6 +43,70 @@ toggle_diagnostics:
       selector:
         text:
 
+force_charge:
+  name: Force Charge
+  description: >-
+    Start ByteWatt force charge using the integration's internal API client.
+    If no system is specified, all detected ByteWatt systems are targeted.
+  fields:
+    limit:
+      name: Charge Limit
+      description: Target SOC limit percentage for force charge
+      required: false
+      example: 95
+      selector:
+        number:
+          min: 1
+          max: 100
+          step: 1
+          unit_of_measurement: "%"
+    charge_power:
+      name: Charge Power
+      description: Optional charge power in watts for the targeted system(s)
+      required: false
+      example: 5000
+      selector:
+        number:
+          min: 0
+          max: 50000
+          step: 100
+          unit_of_measurement: "W"
+    system_id:
+      name: System ID
+      description: Optional specific ByteWatt system ID to target
+      required: false
+      example: "z1fn6iB6DC37K2SAa2s"
+      selector:
+        text:
+    sys_sn:
+      name: Inverter Serial
+      description: Optional inverter serial number for per-inverter targeting
+      required: false
+      example: "25000SP2B5W00253"
+      selector:
+        text:
+
+stop_force_charge:
+  name: Stop Force Charge
+  description: >-
+    Stop active ByteWatt force charge using the integration's internal API client.
+    If no system is specified, all detected ByteWatt systems are targeted.
+  fields:
+    system_id:
+      name: System ID
+      description: Optional specific ByteWatt system ID to target
+      required: false
+      example: "z1fn6iB6DC37K2SAa2s"
+      selector:
+        text:
+    sys_sn:
+      name: Inverter Serial
+      description: Optional inverter serial number associated with the system target
+      required: false
+      example: "25000SP2B5W00253"
+      selector:
+        text:
+
 set_discharge_time:
   name: Set Discharge End Time
   description: Set the end time for battery discharge (legacy service)
@@ -166,10 +230,31 @@ update_battery_settings:
           max: 100
           step: 1
           unit_of_measurement: "%"
+
+update_cycle_strategy:
+  name: Update Cycle Strategy
+  description: >-
+    Update the active cycle-strategy charge/discharge schedule for host/follower style systems.
+    Use this when the control variant is detected as cycle_strategy.
+  fields:
+    start_charge:
+      name: Charge Start Time
+      description: Primary cycle charge start time (HH:MM)
+      example: "22:00"
+      required: false
+      selector:
+        time: {}
+    end_charge:
+      name: Charge End Time
+      description: Primary cycle charge end time (HH:MM)
+      example: "22:30"
+      required: false
+      selector:
+        time: {}
     charge_cap:
       name: Charge Cap
-      description: The maximum battery charge cap to maintain (1-100%)
-      example: 90
+      description: Charge target/cap percentage for the cycle charge window
+      example: 80
       required: false
       selector:
         number:
@@ -177,15 +262,131 @@ update_battery_settings:
           max: 100
           step: 1
           unit_of_measurement: "%"
+    charge_power:
+      name: Charge Power
+      description: Primary cycle charge power in watts
+      example: 5000
+      required: false
+      selector:
+        number:
+          min: 0
+          max: 50000
+          step: 100
+          unit_of_measurement: "W"
+    charge_enabled:
+      name: Charge Enabled
+      description: Enable or disable cycle-strategy charge control
+      required: false
+      selector:
+        boolean: {}
+    start_discharge:
+      name: Discharge Start Time
+      description: Primary cycle discharge start time (HH:MM)
+      example: "16:00"
+      required: false
+      selector:
+        time: {}
+    end_discharge:
+      name: Discharge End Time
+      description: Primary cycle discharge end time (HH:MM)
+      example: "07:15"
+      required: false
+      selector:
+        time: {}
+    minimum_soc:
+      name: Minimum SOC
+      description: Minimum battery SOC for the cycle strategy
+      example: 10
+      required: false
+      selector:
+        number:
+          min: 1
+          max: 100
+          step: 1
+          unit_of_measurement: "%"
+    discharge_power:
+      name: Discharge Power
+      description: Primary cycle discharge power in watts
+      example: 5000
+      required: false
+      selector:
+        number:
+          min: 0
+          max: 50000
+          step: 100
+          unit_of_measurement: "W"
+    discharge_enabled:
+      name: Discharge Enabled
+      description: Enable or disable cycle-strategy discharge control
+      required: false
+      selector:
+        boolean: {}
 
-force_reconnect:
-  name: Force Reconnect
-  description: Force reconnection to the ByteWatt API
-
-health_check:
-  name: Health Check
-  description: Run a comprehensive health check of the ByteWatt integration
-
-toggle_diagnostics:
-  name: Toggle Diagnostics
-  description: Enable or disable diagnostic logging for the ByteWatt integration
+set_cycle_day_schedule:
+  name: Set Cycle Day Schedule
+  description: >-
+    Replace the current day-based cycle strategy with explicit charge and/or discharge
+    window lists. Intended for forecast-driven rolling optimiser control.
+  fields:
+    charge_windows:
+      name: Charge windows JSON
+      description: JSON array of charge window objects with beginTime/endTime/chargeLimit/chargePower
+      example: >-
+        [{"beginTime":"22:00","endTime":"22:15","chargeLimit":80,"chargePower":5000,"sort":1,"weeks":[7,1,2,3,4,5,6],"feedMode":0,"equipGroupId":0,"feedPower":0}]
+      required: false
+      selector:
+        text:
+          multiline: true
+    discharge_windows:
+      name: Discharge windows JSON
+      description: JSON array of discharge window objects with beginTime/endTime/chargeLimit/chargePower
+      example: >-
+        [{"beginTime":"16:00","endTime":"16:15","chargeLimit":15,"chargePower":5000,"sort":1,"weeks":[7,1,2,3,4,5,6],"feedMode":0,"equipGroupId":0,"feedPower":0}]
+      required: false
+      selector:
+        text:
+          multiline: true
+    minimum_soc:
+      name: Minimum SOC
+      description: Default discharge reserve SOC for generated windows
+      example: 15
+      required: false
+      selector:
+        number:
+          min: 1
+          max: 100
+          step: 1
+          unit_of_measurement: "%"
+    charge_cap:
+      name: Charge Cap
+      description: Default charge cap for generated windows
+      example: 80
+      required: false
+      selector:
+        number:
+          min: 1
+          max: 100
+          step: 1
+          unit_of_measurement: "%"
+    charge_power:
+      name: Charge Power
+      description: Default charge power in watts
+      example: 5000
+      required: false
+      selector:
+        number:
+          min: 0
+          max: 50000
+          step: 100
+          unit_of_measurement: "W"
+    discharge_power:
+      name: Discharge Power
+      description: Default discharge power in watts
+      example: 5000
+      required: false
+      selector:
+        number:
+          min: 0
+          max: 50000
+          step: 100
+          unit_of_measurement: "W"

--- a/custom_components/bytewatt/switch.py
+++ b/custom_components/bytewatt/switch.py
@@ -83,7 +83,12 @@ class ByteWattSwitchEntity(CoordinatorEntity, SwitchEntity):
         """Return if entity is available."""
         try:
             client = self.hass.data[DOMAIN][self._config_entry.entry_id]["client"]
-            return hasattr(client.api_client, "_settings_cache") and client.api_client._settings_cache is not None
+            has_cache = hasattr(client.api_client, "_settings_cache") and client.api_client._settings_cache is not None
+            control_data = (self.coordinator.data or {}).get("control_variant", {})
+            variant = control_data.get("effective_variant")
+            if variant and variant != "charge_config":
+                return False
+            return has_cache
         except Exception:
             return False
 

--- a/custom_components/bytewatt/time.py
+++ b/custom_components/bytewatt/time.py
@@ -27,8 +27,12 @@ async def async_setup_entry(
     entities = [
         ByteWattChargeStartTime(coordinator, config_entry),
         ByteWattChargeEndTime(coordinator, config_entry),
+        ByteWattChargeStartTime2(coordinator, config_entry),
+        ByteWattChargeEndTime2(coordinator, config_entry),
         ByteWattDischargeStartTime(coordinator, config_entry),
         ByteWattDischargeEndTime(coordinator, config_entry),
+        ByteWattDischargeStartTime2(coordinator, config_entry),
+        ByteWattDischargeEndTime2(coordinator, config_entry),
     ]
 
     async_add_entities(entities)
@@ -79,6 +83,22 @@ class ByteWattTimeEntity(CoordinatorEntity, TimeEntity):
     def _format_time_for_api(self, time_obj: time) -> str:
         """Format a time object for the API (HH:MM)."""
         return f"{time_obj.hour:02d}:{time_obj.minute:02d}"
+
+    def _effective_control_variant(self) -> Optional[str]:
+        """Return the currently effective control variant."""
+        try:
+            control_data = (self.coordinator.data or {}).get("control_variant", {})
+            return control_data.get("effective_variant")
+        except Exception:
+            return None
+
+    @property
+    def available(self) -> bool:
+        """Only expose legacy time controls for legacy charge-config systems."""
+        variant = self._effective_control_variant()
+        if variant and variant != "charge_config":
+            return False
+        return super().available
 
 
 class ByteWattChargeStartTime(ByteWattTimeEntity):
@@ -255,3 +275,155 @@ class ByteWattDischargeEndTime(ByteWattTimeEntity):
                 _LOGGER.error(f"Failed to update discharge end time to {time_str}")
         except Exception as ex:
             _LOGGER.error(f"Error setting discharge end time to {value}: {ex}")
+
+
+class ByteWattChargeStartTime2(ByteWattTimeEntity):
+    """Time entity for charge start time 2."""
+
+    def __init__(self, coordinator: ByteWattDataUpdateCoordinator, config_entry: ConfigEntry) -> None:
+        super().__init__(
+            coordinator=coordinator,
+            config_entry=config_entry,
+            name="Charge Start Time 2",
+            unique_id="charge_start_time_2",
+            icon="mdi:battery-plus",
+            attribute_name="time_chaf2a",
+        )
+
+    @property
+    def native_value(self) -> Optional[time]:
+        try:
+            client = self.hass.data[DOMAIN][self._config_entry.entry_id]["client"]
+            if hasattr(client.api_client, "_settings_cache") and client.api_client._settings_cache:
+                settings = client.api_client._settings_cache
+                return self._parse_time_string(getattr(settings, self._attribute_name, "00:00"))
+        except Exception as ex:
+            _LOGGER.debug(f"Error getting charge start time 2: {ex}")
+        return None
+
+    async def async_set_value(self, value: time) -> None:
+        try:
+            client = self.hass.data[DOMAIN][self._config_entry.entry_id]["client"]
+            time_str = self._format_time_for_api(value)
+            success = await client.update_battery_settings(charge_start_time_2=time_str)
+            if success:
+                if hasattr(client.api_client, "_settings_cache") and client.api_client._settings_cache:
+                    client.api_client._settings_cache.time_chaf2a = time_str
+                _LOGGER.info(f"Successfully updated charge start time 2 to {time_str}")
+                await self.coordinator.async_request_refresh()
+        except Exception as ex:
+            _LOGGER.error(f"Error setting charge start time 2 to {value}: {ex}")
+
+
+class ByteWattChargeEndTime2(ByteWattTimeEntity):
+    """Time entity for charge end time 2."""
+
+    def __init__(self, coordinator: ByteWattDataUpdateCoordinator, config_entry: ConfigEntry) -> None:
+        super().__init__(
+            coordinator=coordinator,
+            config_entry=config_entry,
+            name="Charge End Time 2",
+            unique_id="charge_end_time_2",
+            icon="mdi:battery-plus-outline",
+            attribute_name="time_chae2a",
+        )
+
+    @property
+    def native_value(self) -> Optional[time]:
+        try:
+            client = self.hass.data[DOMAIN][self._config_entry.entry_id]["client"]
+            if hasattr(client.api_client, "_settings_cache") and client.api_client._settings_cache:
+                settings = client.api_client._settings_cache
+                return self._parse_time_string(getattr(settings, self._attribute_name, "00:00"))
+        except Exception as ex:
+            _LOGGER.debug(f"Error getting charge end time 2: {ex}")
+        return None
+
+    async def async_set_value(self, value: time) -> None:
+        try:
+            client = self.hass.data[DOMAIN][self._config_entry.entry_id]["client"]
+            time_str = self._format_time_for_api(value)
+            success = await client.update_battery_settings(charge_end_time_2=time_str)
+            if success:
+                if hasattr(client.api_client, "_settings_cache") and client.api_client._settings_cache:
+                    client.api_client._settings_cache.time_chae2a = time_str
+                _LOGGER.info(f"Successfully updated charge end time 2 to {time_str}")
+                await self.coordinator.async_request_refresh()
+        except Exception as ex:
+            _LOGGER.error(f"Error setting charge end time 2 to {value}: {ex}")
+
+
+class ByteWattDischargeStartTime2(ByteWattTimeEntity):
+    """Time entity for discharge start time 2."""
+
+    def __init__(self, coordinator: ByteWattDataUpdateCoordinator, config_entry: ConfigEntry) -> None:
+        super().__init__(
+            coordinator=coordinator,
+            config_entry=config_entry,
+            name="Discharge Start Time 2",
+            unique_id="discharge_start_time_2",
+            icon="mdi:battery-minus",
+            attribute_name="time_disf2a",
+        )
+
+    @property
+    def native_value(self) -> Optional[time]:
+        try:
+            client = self.hass.data[DOMAIN][self._config_entry.entry_id]["client"]
+            if hasattr(client.api_client, "_settings_cache") and client.api_client._settings_cache:
+                settings = client.api_client._settings_cache
+                return self._parse_time_string(getattr(settings, self._attribute_name, "00:00"))
+        except Exception as ex:
+            _LOGGER.debug(f"Error getting discharge start time 2: {ex}")
+        return None
+
+    async def async_set_value(self, value: time) -> None:
+        try:
+            client = self.hass.data[DOMAIN][self._config_entry.entry_id]["client"]
+            time_str = self._format_time_for_api(value)
+            success = await client.update_battery_settings(discharge_start_time_2=time_str)
+            if success:
+                if hasattr(client.api_client, "_settings_cache") and client.api_client._settings_cache:
+                    client.api_client._settings_cache.time_disf2a = time_str
+                _LOGGER.info(f"Successfully updated discharge start time 2 to {time_str}")
+                await self.coordinator.async_request_refresh()
+        except Exception as ex:
+            _LOGGER.error(f"Error setting discharge start time 2 to {value}: {ex}")
+
+
+class ByteWattDischargeEndTime2(ByteWattTimeEntity):
+    """Time entity for discharge end time 2."""
+
+    def __init__(self, coordinator: ByteWattDataUpdateCoordinator, config_entry: ConfigEntry) -> None:
+        super().__init__(
+            coordinator=coordinator,
+            config_entry=config_entry,
+            name="Discharge End Time 2",
+            unique_id="discharge_end_time_2",
+            icon="mdi:battery-minus-outline",
+            attribute_name="time_dise2a",
+        )
+
+    @property
+    def native_value(self) -> Optional[time]:
+        try:
+            client = self.hass.data[DOMAIN][self._config_entry.entry_id]["client"]
+            if hasattr(client.api_client, "_settings_cache") and client.api_client._settings_cache:
+                settings = client.api_client._settings_cache
+                return self._parse_time_string(getattr(settings, self._attribute_name, "00:00"))
+        except Exception as ex:
+            _LOGGER.debug(f"Error getting discharge end time 2: {ex}")
+        return None
+
+    async def async_set_value(self, value: time) -> None:
+        try:
+            client = self.hass.data[DOMAIN][self._config_entry.entry_id]["client"]
+            time_str = self._format_time_for_api(value)
+            success = await client.update_battery_settings(discharge_end_time_2=time_str)
+            if success:
+                if hasattr(client.api_client, "_settings_cache") and client.api_client._settings_cache:
+                    client.api_client._settings_cache.time_dise2a = time_str
+                _LOGGER.info(f"Successfully updated discharge end time 2 to {time_str}")
+                await self.coordinator.async_request_refresh()
+        except Exception as ex:
+            _LOGGER.error(f"Error setting discharge end time 2 to {value}: {ex}")


### PR DESCRIPTION
## Summary
- add ByteWatt control-variant detection and API helpers for force-charge status, cycle-strategy payloads, system detail lookups, and richer write paths used by newer Neovolt cloud flows
- expose per-inverter discovery plus dynamic sensors for PV, battery, grid, load, SOC, PV channel power, phase real power, and inverter mode metadata
- extend the integration services/entities so Home Assistant can manage both legacy charge-config accounts and newer cycle-strategy systems more safely

## Why
I was using the integration with a live Neovolt/ByteWatt deployment that includes a host/follower inverter pair. The existing integration could read the aggregate battery data, but newer cloud control variants and per-inverter telemetry were available in the API and not yet surfaced. These changes make the integration usable on those newer systems without requiring separate reverse-engineering in each installation.

## Validation
- `python3 -m compileall /tmp/bytewatt-upstream/custom_components/bytewatt`
- validated the new entities and service paths against a live Home Assistant deployment connected to a real ByteWatt/Neovolt system