### PR TITLE
Add Grid Feed-in Control & Fix charge/discharge API

### DIFF
--- a/custom_components/bytewatt/__init__.py
+++ b/custom_components/bytewatt/__init__.py
@@ -57,6 +57,8 @@ from .const import (
     ATTR_FEEDIN_START,
     ATTR_FEEDIN_END,
     ATTR_FEEDIN_POWER,
+    CONF_HOST_SYSTEM_ID,
+    CONF_HOST_SYS_SN,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -90,7 +92,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         CONF_AUTO_RECONNECT_TIME: options.get(CONF_AUTO_RECONNECT_TIME, DEFAULT_AUTO_RECONNECT_TIME)
     }
 
-    client = ByteWattClient(hass, username, password)
+    client = ByteWattClient(
+        hass, username, password,
+        host_system_id=entry.data.get(CONF_HOST_SYSTEM_ID, ""),
+        host_sys_sn=entry.data.get(CONF_HOST_SYS_SN, ""),
+    )
 
     coordinator = ByteWattDataUpdateCoordinator(
         hass,

--- a/custom_components/bytewatt/__init__.py
+++ b/custom_components/bytewatt/__init__.py
@@ -11,6 +11,7 @@ import homeassistant.helpers.config_validation as cv
 
 from .bytewatt_client import ByteWattClient
 from .coordinator import ByteWattDataUpdateCoordinator
+from .pending import PendingStore
 from .const import (
     DOMAIN,
     CONF_USERNAME,
@@ -47,13 +48,22 @@ from .const import (
     ATTR_END_CHARGE,
     ATTR_MINIMUM_SOC,
     ATTR_CHARGE_CAP,
+    SERVICE_SET_GRID_FEEDIN_ENABLED,
+    SERVICE_SET_GRID_FEEDIN_CUTOFF_SOC,
+    SERVICE_UPDATE_GRID_FEEDIN_SLOT,
+    ATTR_FEEDIN_ENABLED,
+    ATTR_FEEDIN_CUTOFF_SOC,
+    ATTR_FEEDIN_SLOT,
+    ATTR_FEEDIN_START,
+    ATTR_FEEDIN_END,
+    ATTR_FEEDIN_POWER,
 )
 
 _LOGGER = logging.getLogger(__name__)
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
-PLATFORMS = ["sensor", "number", "time", "switch"]
+PLATFORMS = ["sensor", "number", "time", "switch", "button"]
 
 async def async_setup(hass: HomeAssistant, config: dict):
     """Set up the Byte-Watt component."""
@@ -95,6 +105,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.data[DOMAIN][entry.entry_id] = {
         "client": client,
         "coordinator": coordinator,
+        "pending": PendingStore(),
     }
 
     # Start the heartbeat monitoring service if enabled
@@ -110,6 +121,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     # Setup platforms - use the newer async_forward_entry_setups to avoid deprecation warning
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    # Register grid feed-in entities directly now that hass.data is populated
+
 
     return True
 
@@ -571,5 +585,70 @@ async def register_battery_services(hass: HomeAssistant, client: ByteWattClient,
         schema=vol.Schema({
             vol.Optional('enable'): cv.boolean,
             vol.Optional('entry_id'): cv.string
+        })
+    )
+
+    # Grid feed-in services
+    async def handle_set_grid_feedin_enabled(call: ServiceCall):
+        """Handle enabling/disabling grid feed-in function."""
+        enabled = call.data.get(ATTR_FEEDIN_ENABLED)
+        if enabled is None:
+            _LOGGER.error("No feedin_enabled value provided")
+            return
+        for entry in hass.config_entries.async_entries(DOMAIN):
+            c = hass.data[DOMAIN][entry.entry_id]["client"]
+            await c.update_grid_feedin_settings(enabled=enabled)
+
+    async def handle_set_grid_feedin_cutoff_soc(call: ServiceCall):
+        """Handle setting grid feed-in discharging cutoff SOC."""
+        cutoff_soc = call.data.get(ATTR_FEEDIN_CUTOFF_SOC)
+        if cutoff_soc is None:
+            _LOGGER.error("No feedin_cutoff_soc value provided")
+            return
+        for entry in hass.config_entries.async_entries(DOMAIN):
+            c = hass.data[DOMAIN][entry.entry_id]["client"]
+            await c.update_grid_feedin_settings(cutoff_soc=int(cutoff_soc))
+
+    async def handle_update_grid_feedin_slot(call: ServiceCall):
+        """Handle updating a grid feed-in time slot."""
+        slot = call.data.get(ATTR_FEEDIN_SLOT)
+        if slot is None:
+            _LOGGER.error("No slot number provided")
+            return
+        slot_index = int(slot) - 1  # convert 1-based to 0-based
+        for entry in hass.config_entries.async_entries(DOMAIN):
+            c = hass.data[DOMAIN][entry.entry_id]["client"]
+            await c.update_grid_feedin_settings(
+                slot_index=slot_index,
+                slot_start=call.data.get(ATTR_FEEDIN_START),
+                slot_end=call.data.get(ATTR_FEEDIN_END),
+                slot_power=call.data.get(ATTR_FEEDIN_POWER),
+            )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_GRID_FEEDIN_ENABLED,
+        handle_set_grid_feedin_enabled,
+        schema=vol.Schema({vol.Required(ATTR_FEEDIN_ENABLED): cv.boolean})
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_GRID_FEEDIN_CUTOFF_SOC,
+        handle_set_grid_feedin_cutoff_soc,
+        schema=vol.Schema({
+            vol.Required(ATTR_FEEDIN_CUTOFF_SOC): vol.All(vol.Coerce(int), vol.Range(min=0, max=100))
+        })
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_UPDATE_GRID_FEEDIN_SLOT,
+        handle_update_grid_feedin_slot,
+        schema=vol.Schema({
+            vol.Required(ATTR_FEEDIN_SLOT): vol.All(vol.Coerce(int), vol.Range(min=1, max=6)),
+            vol.Optional(ATTR_FEEDIN_START): cv.string,
+            vol.Optional(ATTR_FEEDIN_END): cv.string,
+            vol.Optional(ATTR_FEEDIN_POWER): vol.All(vol.Coerce(int), vol.Range(min=0, max=20000)),
         })
     )

--- a/custom_components/bytewatt/api/neovolt_client.py
+++ b/custom_components/bytewatt/api/neovolt_client.py
@@ -538,16 +538,13 @@ class NeovoltClient:
                                           minimum_soc: int = None,
                                           charge_cap: int = None,
                                           discharge_time_control: bool = None,
-                                          grid_charging: bool = None) -> bool:
+                                          grid_charging: bool = None,
+                                          charge_power: int = None,
+                                          discharge_power: int = None) -> bool:
         """Update battery settings."""
         try:
-            # Import the settings API
             from .settings import BatterySettingsAPI
-            
-            # Create settings API instance
             settings_api = BatterySettingsAPI(self)
-            
-            # Use the async method directly
             result = await settings_api.update_battery_settings(
                 discharge_start_time,
                 discharge_end_time,
@@ -556,7 +553,9 @@ class NeovoltClient:
                 minimum_soc,
                 charge_cap,
                 discharge_time_control,
-                grid_charging
+                grid_charging,
+                charge_power,
+                discharge_power,
             )
             
             # If successful, set fresh update flag and schedule auto-fetch from API

--- a/custom_components/bytewatt/api/neovolt_client.py
+++ b/custom_components/bytewatt/api/neovolt_client.py
@@ -693,3 +693,46 @@ class NeovoltClient:
         except Exception as error:
             _LOGGER.error("Error making PUT request: %s", error)
             return None
+
+    async def async_get_grid_feedin_settings(self):
+        """Fetch and cache grid feed-in settings."""
+        try:
+            from .settings import GridFeedInSettingsAPI
+            api = GridFeedInSettingsAPI(self)
+            if hasattr(self, "_grid_feedin_cache") and self._grid_feedin_cache:
+                api._cache = self._grid_feedin_cache
+            settings = await api.fetch_current_settings()
+            if settings:
+                self._grid_feedin_cache = settings
+            return settings
+        except Exception as error:
+            _LOGGER.error("Error fetching grid feed-in settings: %s", error)
+            return None
+
+    async def async_update_grid_feedin_settings(self,
+                                                enabled: bool = None,
+                                                cutoff_soc: float = None,
+                                                slot_index: int = None,
+                                                slot_start: str = None,
+                                                slot_end: str = None,
+                                                slot_power: int = None) -> bool:
+        """Update grid feed-in settings."""
+        try:
+            from .settings import GridFeedInSettingsAPI
+            api = GridFeedInSettingsAPI(self)
+            if hasattr(self, "_grid_feedin_cache") and self._grid_feedin_cache:
+                api._cache = self._grid_feedin_cache
+            result = await api.update_settings(
+                enabled=enabled,
+                cutoff_soc=cutoff_soc,
+                slot_index=slot_index,
+                slot_start=slot_start,
+                slot_end=slot_end,
+                slot_power=slot_power,
+            )
+            if result and api._cache:
+                self._grid_feedin_cache = api._cache
+            return result
+        except Exception as error:
+            _LOGGER.error("Error updating grid feed-in settings: %s", error)
+            return False

--- a/custom_components/bytewatt/api/neovolt_client.py
+++ b/custom_components/bytewatt/api/neovolt_client.py
@@ -25,6 +25,8 @@ class NeovoltClient:
         username: str, 
         password: str, 
         base_url: str = DEFAULT_BASE_URL,
+        host_system_id: str = "",
+        host_sys_sn: str = "",
     ) -> None:
         """Initialize the API client."""
         self.hass = hass
@@ -36,6 +38,9 @@ class NeovoltClient:
         self._settings_cache = None
         self._fresh_settings_update = False
         self._settings_update_time = None
+        self.host_system_id = host_system_id   # systemId of the Host inverter
+        self.host_sys_sn = host_sys_sn         # sysSn of the Host inverter
+        self._inverter_list_cache = []          # cached from getCustomMenuEssList
     
     async def async_login(self) -> bool:
         """Login to the Neovolt API using encrypted password."""

--- a/custom_components/bytewatt/api/settings.py
+++ b/custom_components/bytewatt/api/settings.py
@@ -185,11 +185,28 @@ class GridFeedInSettingsAPI:
         self._cache = None
 
     async def _get_system_id(self) -> str:
+        """Return the configured Host inverter systemId.
+
+        Uses the value set during config flow setup. Falls back to fetching
+        the list and picking the first entry for single-inverter setups or
+        legacy configs that predate the inverter selection step.
+        """
+        # Use the pre-configured value if available
+        if getattr(self.api_client, "host_system_id", ""):
+            return self.api_client.host_system_id
+
+        # Fallback: fetch list and take first entry (single inverter or legacy)
+        _LOGGER.warning(
+            "No host_system_id configured — fetching inverter list and using first entry. "
+            "Re-configure the integration to select the correct Host inverter."
+        )
         response = await self.api_client._async_get(self.SYSTEM_LIST_ENDPOINT)
         if response and response.get("code") == 200:
             data = response.get("data") or []
             if data:
-                return data[0].get("systemId", "")
+                system_id = data[0].get("systemId", "")
+                _LOGGER.warning("Using systemId=%s as fallback", system_id)
+                return system_id
         _LOGGER.error("Could not resolve systemId for grid feed-in")
         return ""
 

--- a/custom_components/bytewatt/api/settings.py
+++ b/custom_components/bytewatt/api/settings.py
@@ -29,14 +29,19 @@ class BatterySettingsAPI:
         self._settings_cache: Optional[CycleStrategy] = None
         self._settings_loaded = False
 
+    def _host_id(self) -> str:
+        """Return the configured host systemId, or empty string for single-inverter setups."""
+        return getattr(self.api_client, "host_system_id", "")
+
     # ------------------------------------------------------------------
     # Fetch
     # ------------------------------------------------------------------
 
     async def fetch_current_settings(self, max_retries: int = 3, retry_delay: int = 1) -> Optional[CycleStrategy]:
         """Fetch cycle strategy from the API and cache it."""
+        endpoint = f"{self.GET_ENDPOINT}{self._host_id()}"
         for attempt in range(max_retries):
-            response = await self.api_client._async_get(self.GET_ENDPOINT)
+            response = await self.api_client._async_get(endpoint)
 
             if not response:
                 if attempt < max_retries - 1:
@@ -46,15 +51,17 @@ class BatterySettingsAPI:
             if response.get("code") == 6069:
                 _LOGGER.warning("Session expired fetching cycle strategy, re-logging in")
                 if await self.api_client.async_login():
-                    response = await self.api_client._async_get(self.GET_ENDPOINT)
+                    response = await self.api_client._async_get(endpoint)
 
             if response and response.get("code") == 200 and "data" in response:
                 settings = CycleStrategy.from_api_response(response["data"])
                 settings.last_updated = dt_util.utcnow().isoformat()
+                settings.host_system_id = self._host_id()  # store so to_dict can use it
                 self._settings_cache = settings
                 self._settings_loaded = True
                 _LOGGER.debug(
-                    "Fetched cycle strategy: charge=%s-%s, discharge=%s-%s, batUseCap=%.0f%%",
+                    "Fetched cycle strategy (id=%s): charge=%s-%s, discharge=%s-%s, batUseCap=%.0f%%",
+                    self._host_id(),
                     settings.time_chaf1a, settings.time_chae1a,
                     settings.time_disf1a, settings.time_dise1a,
                     settings.bat_use_cap,
@@ -89,12 +96,13 @@ class BatterySettingsAPI:
                                       charge_cap: int = None,
                                       discharge_time_control: bool = None,
                                       grid_charging: bool = None,
+                                      charge_power: int = None,
+                                      discharge_power: int = None,
                                       max_retries: int = 5,
                                       retry_delay: int = 1) -> bool:
         """Merge changes into current settings and PUT to the API."""
         current = await self.get_current_settings()
 
-        # Apply time changes via the alias properties
         if charge_start_time:
             sanitized = sanitize_time_format(charge_start_time)
             if sanitized:
@@ -127,12 +135,20 @@ class BatterySettingsAPI:
         if grid_charging is not None:
             current.grid_charge_cycle = 1 if grid_charging else 0
 
+        if charge_power is not None and current.charge_slots:
+            current.charge_slots[0].charge_power = int(charge_power)
+
+        if discharge_power is not None and current.discharge_slots:
+            current.discharge_slots[0].charge_power = int(discharge_power)
+
         return await self._send_settings(current, max_retries, retry_delay)
 
     async def _send_settings(self, settings: CycleStrategy,
                              max_retries: int = 5, retry_delay: int = 1) -> bool:
         """PUT settings to the API."""
         payload = settings.to_dict()
+        # Always use the configured host systemId in the payload
+        payload["id"] = self._host_id()
 
         for attempt in range(max_retries):
             response = await self.api_client._async_put(self.PUT_ENDPOINT, payload)

--- a/custom_components/bytewatt/api/settings.py
+++ b/custom_components/bytewatt/api/settings.py
@@ -1,13 +1,11 @@
 """Battery settings API interface for Byte-Watt integration."""
 import asyncio
 import logging
-import time
-from datetime import datetime
-from typing import Optional, Dict, Any, Tuple
+from typing import Optional, Dict, Any
 
 from homeassistant.util import dt as dt_util
 
-from ..models import BatterySettings
+from ..models import CycleStrategy
 from ..utilities.time_utils import sanitize_time_format
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
@@ -17,383 +15,269 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class BatterySettingsAPI:
-    """API client for battery settings."""
-    
+    """API client for battery cycle strategy settings.
+
+    Uses getCycleStrategy / setCycleStrategy — the endpoints the
+    Byte-Watt website actually uses.
+    """
+
+    GET_ENDPOINT = "api/iterate/sysSet/getCycleStrategy?id="
+    PUT_ENDPOINT = "api/iterate/sysSet/setCycleStrategy"
+
     def __init__(self, api_client: 'NeovoltClient'):
-        """Initialize the battery settings API client."""
         self.api_client = api_client
-        
-        # Default settings cache (used only if API fetch fails)
-        self._settings_cache = BatterySettings()
+        self._settings_cache: Optional[CycleStrategy] = None
         self._settings_loaded = False
-    
-    def validate_settings_input(self, 
-                              discharge_start_time, 
-                              discharge_end_time, 
-                              charge_start_time, 
-                              charge_end_time, 
-                              minimum_soc,
-                              charge_cap=None):
-        """
-        Validate input parameters for battery settings.
-        
-        Args:
-            discharge_start_time: Time to start battery discharge
-            discharge_end_time: Time to end battery discharge
-            charge_start_time: Time to start battery charging
-            charge_end_time: Time to end battery charging
-            minimum_soc: Minimum state of charge percentage
-            charge_cap: Maximum charge cap percentage
-            
-        Returns:
-            Tuple of validated values (discharge_start, discharge_end, charge_start, charge_end, min_soc, max_charge_cap)
-            Invalid values will be None
-        """
-        # Sanitize time formats
-        discharge_start = sanitize_time_format(discharge_start_time)
-        discharge_end = sanitize_time_format(discharge_end_time)
-        charge_start = sanitize_time_format(charge_start_time)
-        charge_end = sanitize_time_format(charge_end_time)
-        
-        # Validate minimum SOC
-        min_soc = None
-        if minimum_soc is not None:
-            try:
-                min_soc_val = int(minimum_soc)
-                if 1 <= min_soc_val <= 100:
-                    min_soc = min_soc_val
-                else:
-                    _LOGGER.error(f"Minimum SOC must be between 1 and 100, got {minimum_soc}")
-            except (ValueError, TypeError):
-                _LOGGER.error(f"Invalid minimum SOC value: {minimum_soc}")
-        
-        # Validate charge cap
-        max_charge_cap = None
-        if charge_cap is not None:
-            try:
-                charge_cap_val = int(charge_cap)
-                if 1 <= charge_cap_val <= 100:
-                    max_charge_cap = charge_cap_val
-                else:
-                    _LOGGER.error(f"Charge cap must be between 1 and 100, got {charge_cap}")
-            except (ValueError, TypeError):
-                _LOGGER.error(f"Invalid charge cap value: {charge_cap}")
-        
-        return discharge_start, discharge_end, charge_start, charge_end, min_soc, max_charge_cap
-    
-    def validate_boolean_setting(self, value: any, setting_name: str) -> int:
-        """
-        Validate boolean setting input and convert to API integer format (0/1).
-        
-        Args:
-            value: Boolean value to validate (can be bool, int, or string)
-            setting_name: Name of the setting for logging purposes
-            
-        Returns:
-            0 or 1 for API, or None if invalid
-        """
-        if value is None:
-            return None
-            
-        try:
-            # Handle different input types
-            if isinstance(value, bool):
-                return 1 if value else 0
-            elif isinstance(value, int):
-                if value in [0, 1]:
-                    return value
-                else:
-                    _LOGGER.error(f"{setting_name} must be 0 or 1, got {value}")
-                    return None
-            elif isinstance(value, str):
-                if value.lower() in ['true', '1', 'on', 'enabled']:
-                    return 1
-                elif value.lower() in ['false', '0', 'off', 'disabled']:
-                    return 0
-                else:
-                    _LOGGER.error(f"Invalid {setting_name} value: {value}")
-                    return None
-            else:
-                _LOGGER.error(f"Invalid {setting_name} type: {type(value)}")
-                return None
-        except Exception as ex:
-            _LOGGER.error(f"Error validating {setting_name}: {ex}")
-            return None
-    
-    async def fetch_current_settings(self, max_retries: int = 3, retry_delay: int = 1) -> Optional[BatterySettings]:
-        """
-        Fetch current battery settings directly from the API using new endpoint.
-        
-        Args:
-            max_retries: Maximum number of retry attempts
-            retry_delay: Delay between retries in seconds
-            
-        Returns:
-            BatterySettings if successful, None if failed
-        """
-        # Use new API endpoint with empty id= to get settings for all devices
-        endpoint = "api/iterate/sysSet/getChargeConfigInfo?id="
-        
+
+    # ------------------------------------------------------------------
+    # Fetch
+    # ------------------------------------------------------------------
+
+    async def fetch_current_settings(self, max_retries: int = 3, retry_delay: int = 1) -> Optional[CycleStrategy]:
+        """Fetch cycle strategy from the API and cache it."""
         for attempt in range(max_retries):
-            response = await self.api_client._async_get(endpoint)
-            
+            response = await self.api_client._async_get(self.GET_ENDPOINT)
+
             if not response:
                 if attempt < max_retries - 1:
                     await asyncio.sleep(retry_delay)
                 continue
-                
-            if "data" not in response or "code" not in response or response["code"] != 200:
-                # Check for session expiry
-                if response.get("code") == 6069:
-                    _LOGGER.warning("Session expired (code 6069), attempting to re-login")
-                    if await self.api_client.async_login():
-                        # Retry immediately after successful re-login
-                        response = await self.api_client._async_get(endpoint)
-                        if response and "data" in response and response.get("code") == 200:
-                            # Success! Extract the settings
-                            settings = BatterySettings.from_api_response(response["data"])
-                            settings.last_updated = dt_util.utcnow().isoformat()
-                            
-                            # Update our settings cache
-                            self._settings_cache = settings
-                            self._settings_loaded = True
-                            
-                            _LOGGER.debug(f"Successfully fetched current settings after re-login")
-                            return settings
-                
-                _LOGGER.error(f"Unexpected response format (attempt {attempt+1}/{max_retries}): {response}")
-                if attempt < max_retries - 1:
-                    await asyncio.sleep(retry_delay)
-                continue
-                
-            # Success! Extract the settings
-            settings = BatterySettings.from_api_response(response["data"])
-            settings.last_updated = dt_util.utcnow().isoformat()
-            
-            # Update our settings cache
-            self._settings_cache = settings
-            self._settings_loaded = True
-            
-            _LOGGER.debug(f"Successfully fetched current settings from new API")
-            _LOGGER.debug(f"Current settings: " +
-                         f"Charge: {settings.time_chaf1a}-{settings.time_chae1a}, " +
-                         f"Discharge: {settings.time_disf1a}-{settings.time_dise1a}, " +
-                         f"Min SOC: {settings.bat_use_cap}%")
-            
-            return settings
-        
-        _LOGGER.error(f"Failed to fetch current settings after {max_retries} attempts")
-        # If we failed to fetch from API, use the cached settings or defaults
-        if self._settings_loaded:
-            _LOGGER.warning("Using cached settings as fallback")
-            return self._settings_cache
-        else:
-            _LOGGER.warning("Using default settings as fallback")
-            return self._settings_cache
-    
-    async def get_current_settings(self, max_retries: int = 3, retry_delay: int = 1) -> BatterySettings:
-        """
-        Get current battery settings - first try API, then fallback to cache.
-        
-        Args:
-            max_retries: Maximum number of retry attempts
-            retry_delay: Delay between retries in seconds
-            
-        Returns:
-            Current battery settings
-        """
-        # First try to fetch from API
-        settings = await self.fetch_current_settings(max_retries, retry_delay)
-        
-        # If that failed but we have cached settings, use those
-        if settings is None and self._settings_loaded:
-            _LOGGER.warning("Using cached settings")
-            return self._settings_cache
-            
-        # If we still don't have settings, use the defaults
-        if settings is None:
-            _LOGGER.warning("Using default settings")
-            return self._settings_cache
-            
-        return settings
-    
-    async def update_battery_settings(self, 
-                              discharge_start_time=None, 
-                              discharge_end_time=None,
-                              charge_start_time=None,
-                              charge_end_time=None,
-                              minimum_soc=None,
-                              charge_cap=None,
-                              discharge_time_control=None,
-                              grid_charging=None,
-                              max_retries: int = 5, 
-                              retry_delay: int = 1) -> bool:
-        """
-        Update battery settings with API fetch to preserve existing settings.
-        
-        Args:
-            discharge_start_time: Time to start battery discharge (format HH:MM)
-            discharge_end_time: Time to end battery discharge (format HH:MM)
-            charge_start_time: Time to start battery charging (format HH:MM)
-            charge_end_time: Time to end battery charging (format HH:MM)
-            minimum_soc: Minimum state of charge percentage to maintain (1-100)
-            charge_cap: Maximum charge cap percentage (1-100)
-            discharge_time_control: Enable/disable discharge time control (bool)
-            grid_charging: Enable/disable grid charging (bool)
-            max_retries: Maximum number of retry attempts
-            retry_delay: Delay between retries in seconds
-            
-        Returns:
-            True if successful, False otherwise
-        """
-        # Validate all inputs
-        discharge_start, discharge_end, charge_start, charge_end, min_soc, max_charge_cap = self.validate_settings_input(
-            discharge_start_time, discharge_end_time, charge_start_time, charge_end_time, minimum_soc, charge_cap
-        )
-        
-        # Validate boolean settings
-        ctr_dis_value = self.validate_boolean_setting(discharge_time_control, "discharge_time_control")
-        grid_charge_value = self.validate_boolean_setting(grid_charging, "grid_charging")
-        
-        # Check if any changes were made
-        if (discharge_start is None and discharge_end is None and 
-            charge_start is None and charge_end is None and min_soc is None and max_charge_cap is None and
-            ctr_dis_value is None and grid_charge_value is None):
-            _LOGGER.warning("No valid battery settings provided, nothing to update")
-            return False
-        
-        # Get current settings from the API - this will fetch from API or use cache as fallback
-        current_settings = await self.get_current_settings()
-        
-        # Create a copy of the current settings
-        settings = current_settings
-        
-        # Update settings with provided values (only if they're valid)
-        if discharge_start is not None:
-            settings.time_disf1a = discharge_start
-            _LOGGER.debug(f"Updating discharge start time to {discharge_start}")
-        
-        if discharge_end is not None:
-            settings.time_dise1a = discharge_end
-            _LOGGER.debug(f"Updating discharge end time to {discharge_end}")
-        
-        if charge_start is not None:
-            settings.time_chaf1a = charge_start
-            _LOGGER.debug(f"Updating charge start time to {charge_start}")
-        
-        if charge_end is not None:
-            settings.time_chae1a = charge_end
-            _LOGGER.debug(f"Updating charge end time to {charge_end}")
-        
-        if min_soc is not None:
-            settings.bat_use_cap = min_soc
-            _LOGGER.debug(f"Updating minimum SOC to {min_soc}%")
-        
-        if max_charge_cap is not None:
-            settings.bat_high_cap = str(max_charge_cap)
-            _LOGGER.debug(f"Updating charge cap to {max_charge_cap}%")
-        
-        if ctr_dis_value is not None:
-            settings.ctr_dis = ctr_dis_value
-            _LOGGER.debug(f"Updating discharge time control to {ctr_dis_value} ({'enabled' if ctr_dis_value else 'disabled'})")
-        
-        if grid_charge_value is not None:
-            settings.grid_charge = grid_charge_value
-            _LOGGER.debug(f"Updating grid charging to {grid_charge_value} ({'enabled' if grid_charge_value else 'disabled'})")
-        
-        # Send the updated settings to the server
-        return await self._send_battery_settings(settings, max_retries, retry_delay)
-    
-    async def _send_battery_settings(self, 
-                              settings: BatterySettings, 
-                              max_retries: int = 5, 
-                              retry_delay: int = 1) -> bool:
-        """
-        Internal method to send battery settings to the server.
-        
-        Args:
-            settings: Battery settings to send
-            max_retries: Maximum number of retry attempts
-            retry_delay: Delay between retries in seconds
-            
-        Returns:
-            True if successful, False otherwise
-        """
-        endpoint = "api/iterate/sysSet/updateChargeConfigInfo"
-        
-        for attempt in range(max_retries):
-            response = await self.api_client._async_put(endpoint, settings.to_dict())
-            
-            if not response:
-                if attempt < max_retries - 1:
-                    await asyncio.sleep(retry_delay)
-                continue
-                
-            # Check for successful response based on new API format
-            if response.get("code") == 200 and response.get("msg") == "Success":
-                _LOGGER.debug(f"Successfully updated battery settings using new API")
-                # Update settings cache with the successfully sent settings
+
+            if response.get("code") == 6069:
+                _LOGGER.warning("Session expired fetching cycle strategy, re-logging in")
+                if await self.api_client.async_login():
+                    response = await self.api_client._async_get(self.GET_ENDPOINT)
+
+            if response and response.get("code") == 200 and "data" in response:
+                settings = CycleStrategy.from_api_response(response["data"])
+                settings.last_updated = dt_util.utcnow().isoformat()
                 self._settings_cache = settings
                 self._settings_loaded = True
-                
-                # Log the updated settings
-                _LOGGER.debug(f"Updated settings: " +
-                            f"Charge: {settings.time_chaf1a}-{settings.time_chae1a}, " +
-                            f"Discharge: {settings.time_disf1a}-{settings.time_dise1a}, " +
-                            f"Min SOC: {settings.bat_use_cap}%")
-                return True
-            elif response.get("code") == 9007:
-                _LOGGER.warning(f"Network exception from server (attempt {attempt+1}/{max_retries}): {response.get('msg', 'Unknown error')}")
-                # Server is reporting a network issue, let's retry
+                _LOGGER.debug(
+                    "Fetched cycle strategy: charge=%s-%s, discharge=%s-%s, batUseCap=%.0f%%",
+                    settings.time_chaf1a, settings.time_chae1a,
+                    settings.time_disf1a, settings.time_dise1a,
+                    settings.bat_use_cap,
+                )
+                return settings
+
+            _LOGGER.error("Unexpected response fetching cycle strategy (attempt %d/%d): %s",
+                          attempt + 1, max_retries, response)
+            if attempt < max_retries - 1:
+                await asyncio.sleep(retry_delay)
+
+        return self._settings_cache  # cached fallback
+
+    async def get_current_settings(self) -> CycleStrategy:
+        """Return cached settings, fetching if not yet loaded."""
+        if not self._settings_loaded or self._settings_cache is None:
+            result = await self.fetch_current_settings()
+            if result:
+                return result
+        return self._settings_cache or CycleStrategy()
+
+    # ------------------------------------------------------------------
+    # Update
+    # ------------------------------------------------------------------
+
+    async def update_battery_settings(self,
+                                      discharge_start_time: str = None,
+                                      discharge_end_time: str = None,
+                                      charge_start_time: str = None,
+                                      charge_end_time: str = None,
+                                      minimum_soc: int = None,
+                                      charge_cap: int = None,
+                                      discharge_time_control: bool = None,
+                                      grid_charging: bool = None,
+                                      max_retries: int = 5,
+                                      retry_delay: int = 1) -> bool:
+        """Merge changes into current settings and PUT to the API."""
+        current = await self.get_current_settings()
+
+        # Apply time changes via the alias properties
+        if charge_start_time:
+            sanitized = sanitize_time_format(charge_start_time)
+            if sanitized:
+                current.time_chaf1a = sanitized
+
+        if charge_end_time:
+            sanitized = sanitize_time_format(charge_end_time)
+            if sanitized:
+                current.time_chae1a = sanitized
+
+        if discharge_start_time:
+            sanitized = sanitize_time_format(discharge_start_time)
+            if sanitized:
+                current.time_disf1a = sanitized
+
+        if discharge_end_time:
+            sanitized = sanitize_time_format(discharge_end_time)
+            if sanitized:
+                current.time_dise1a = sanitized
+
+        if minimum_soc is not None:
+            current.bat_use_cap = float(minimum_soc)
+
+        if charge_cap is not None:
+            current.bat_high_cap = str(charge_cap)
+
+        if discharge_time_control is not None:
+            current.ctr_dis_cycle = 1 if discharge_time_control else 0
+
+        if grid_charging is not None:
+            current.grid_charge_cycle = 1 if grid_charging else 0
+
+        return await self._send_settings(current, max_retries, retry_delay)
+
+    async def _send_settings(self, settings: CycleStrategy,
+                             max_retries: int = 5, retry_delay: int = 1) -> bool:
+        """PUT settings to the API."""
+        payload = settings.to_dict()
+
+        for attempt in range(max_retries):
+            response = await self.api_client._async_put(self.PUT_ENDPOINT, payload)
+
+            if not response:
                 if attempt < max_retries - 1:
                     await asyncio.sleep(retry_delay)
                 continue
-            elif response.get("code") == 6069:
-                # Session expired during settings update
-                _LOGGER.warning("Session expired (code 6069), attempting to re-login")
+
+            if response.get("code") == 6069:
+                _LOGGER.warning("Session expired sending cycle strategy, re-logging in")
                 if await self.api_client.async_login():
-                    # Retry immediately after successful re-login
-                    response = await self.api_client._async_put(endpoint, settings.to_dict())
-                    if response and response.get("code") == 200 and response.get("msg") == "Success":
-                        _LOGGER.debug(f"Successfully updated battery settings after re-login")
-                        # Update settings cache with the successfully sent settings
-                        self._settings_cache = settings
-                        self._settings_loaded = True
-                        return True
-                
-                # If re-login or retry failed, continue to next attempt
-                if attempt < max_retries - 1:
-                    await asyncio.sleep(retry_delay)
-                continue
-            else:
-                _LOGGER.error(f"Unexpected response when setting battery parameters: {response}")
-                if attempt < max_retries - 1:
-                    await asyncio.sleep(retry_delay)
-                continue
-        
-        _LOGGER.error(f"Failed to update battery settings after {max_retries} attempts")
+                    response = await self.api_client._async_put(self.PUT_ENDPOINT, payload)
+
+            if response and response.get("code") == 200 and response.get("msg") == "Success":
+                self._settings_cache = settings
+                self._settings_loaded = True
+                _LOGGER.info("Cycle strategy updated successfully")
+                return True
+
+            _LOGGER.error("Failed to update cycle strategy (attempt %d/%d): %s",
+                          attempt + 1, max_retries, response)
+            if attempt < max_retries - 1:
+                await asyncio.sleep(retry_delay)
+
         return False
-    
+
+    # Legacy method kept for backward compatibility
     async def set_battery_settings(self, end_discharge="23:00", max_retries: int = 5, retry_delay: int = 1) -> bool:
-        """
-        Legacy method for backward compatibility - updates only the discharge end time.
-        
-        Args:
-            end_discharge: Time to end battery discharge (format HH:MM)
-            max_retries: Maximum number of retry attempts
-            retry_delay: Delay between retries in seconds
-            
-        Returns:
-            True if successful, False otherwise
-        """
-        # Sanitize the time format
-        sanitized_end_discharge = sanitize_time_format(end_discharge)
-        if not sanitized_end_discharge:
-            _LOGGER.error(f"Invalid end discharge time format: {end_discharge}")
-            return False
-            
         return await self.update_battery_settings(
-            discharge_end_time=sanitized_end_discharge,
+            discharge_end_time=sanitize_time_format(end_discharge),
             max_retries=max_retries,
-            retry_delay=retry_delay
+            retry_delay=retry_delay,
         )
+
+
+# ---------------------------------------------------------------------------
+# Grid feed-in settings API (unchanged from previous work)
+# ---------------------------------------------------------------------------
+
+class GridFeedInSettingsAPI:
+    """API client for grid feed-in control settings."""
+
+    GET_ENDPOINT = "api/iterate/sysSet/getFeedStrategyList"
+    POST_ENDPOINT = "api/iterate/sysSet/saveFeedStrategy"
+    SYSTEM_LIST_ENDPOINT = "api/stable/home/getCustomMenuEssList?inverterMode=0"
+
+    def __init__(self, api_client: 'NeovoltClient'):
+        self.api_client = api_client
+        self._cache = None
+
+    async def _get_system_id(self) -> str:
+        response = await self.api_client._async_get(self.SYSTEM_LIST_ENDPOINT)
+        if response and response.get("code") == 200:
+            data = response.get("data") or []
+            if data:
+                return data[0].get("systemId", "")
+        _LOGGER.error("Could not resolve systemId for grid feed-in")
+        return ""
+
+    async def fetch_current_settings(self, max_retries: int = 3, retry_delay: int = 1):
+        from ..models import GridFeedInSettings
+
+        system_id = await self._get_system_id()
+        if not system_id:
+            return self._cache
+
+        endpoint = f"{self.GET_ENDPOINT}?id={system_id}"
+
+        for attempt in range(max_retries):
+            response = await self.api_client._async_get(endpoint)
+
+            if not response:
+                if attempt < max_retries - 1:
+                    await asyncio.sleep(retry_delay)
+                continue
+
+            if response.get("code") == 6069:
+                if await self.api_client.async_login():
+                    response = await self.api_client._async_get(endpoint)
+
+            if response and response.get("code") == 200 and "data" in response:
+                settings = GridFeedInSettings.from_api_response(response["data"], system_id)
+                self._cache = settings
+                return settings
+
+            _LOGGER.error("Unexpected response fetching grid feed-in (attempt %d/%d): %s",
+                          attempt + 1, max_retries, response)
+            if attempt < max_retries - 1:
+                await asyncio.sleep(retry_delay)
+
+        return self._cache
+
+    async def update_settings(self,
+                              enabled: bool = None,
+                              cutoff_soc: float = None,
+                              slot_index: int = None,
+                              slot_start: str = None,
+                              slot_end: str = None,
+                              slot_power: int = None,
+                              max_retries: int = 5,
+                              retry_delay: int = 1) -> bool:
+        from ..models import GridFeedInSettings, GridFeedInSlot
+
+        current = await self.fetch_current_settings()
+        if current is None:
+            current = GridFeedInSettings()
+
+        if enabled is not None:
+            current.enabled = enabled
+        if cutoff_soc is not None:
+            current.battery_feed_cutoff_soc = float(cutoff_soc)
+        if slot_index is not None:
+            while len(current.slots) <= slot_index:
+                current.slots.append(GridFeedInSlot(sort=len(current.slots) + 1))
+            slot = current.slots[slot_index]
+            if slot_start is not None:
+                slot.start = slot_start
+            if slot_end is not None:
+                slot.end = slot_end
+            if slot_power is not None:
+                slot.feed_power = slot_power
+
+        payload = current.to_dict()
+
+        for attempt in range(max_retries):
+            response = await self.api_client._async_post(self.POST_ENDPOINT, payload)
+
+            if not response:
+                if attempt < max_retries - 1:
+                    await asyncio.sleep(retry_delay)
+                continue
+
+            if response.get("code") == 6069:
+                if await self.api_client.async_login():
+                    response = await self.api_client._async_post(self.POST_ENDPOINT, payload)
+
+            if response and response.get("code") == 200:
+                self._cache = current
+                _LOGGER.info("Grid feed-in settings saved successfully")
+                return True
+
+            _LOGGER.error("Failed to save grid feed-in (attempt %d/%d): %s",
+                          attempt + 1, max_retries, response)
+            if attempt < max_retries - 1:
+                await asyncio.sleep(retry_delay)
+
+        return False

--- a/custom_components/bytewatt/button.py
+++ b/custom_components/bytewatt/button.py
@@ -1,0 +1,2 @@
+"""Button platform for Byte-Watt integration."""
+from .pending import async_setup_entry  # noqa: F401

--- a/custom_components/bytewatt/bytewatt_client.py
+++ b/custom_components/bytewatt/bytewatt_client.py
@@ -52,3 +52,24 @@ class ByteWattClient:
             discharge_time_control=discharge_time_control,
             grid_charging=grid_charging
         )
+
+    async def get_grid_feedin_settings(self):
+        """Get grid feed-in settings."""
+        return await self.api_client.async_get_grid_feedin_settings()
+
+    async def update_grid_feedin_settings(self,
+                                          enabled: bool = None,
+                                          cutoff_soc: float = None,
+                                          slot_index: int = None,
+                                          slot_start: str = None,
+                                          slot_end: str = None,
+                                          slot_power: int = None) -> bool:
+        """Update grid feed-in settings."""
+        return await self.api_client.async_update_grid_feedin_settings(
+            enabled=enabled,
+            cutoff_soc=cutoff_soc,
+            slot_index=slot_index,
+            slot_start=slot_start,
+            slot_end=slot_end,
+            slot_power=slot_power,
+        )

--- a/custom_components/bytewatt/bytewatt_client.py
+++ b/custom_components/bytewatt/bytewatt_client.py
@@ -13,12 +13,17 @@ _LOGGER = logging.getLogger(__name__)
 class ByteWattClient:
     """Client for interacting with the Byte-Watt API."""
     
-    def __init__(self, hass: HomeAssistant, username: str, password: str):
+    def __init__(self, hass: HomeAssistant, username: str, password: str,
+                 host_system_id: str = "", host_sys_sn: str = ""):
         """Initialize with login credentials."""
         self.hass = hass
         self.username = username
         self.password = password
-        self.api_client = NeovoltClient(hass, username, password)
+        self.api_client = NeovoltClient(
+            hass, username, password,
+            host_system_id=host_system_id,
+            host_sys_sn=host_sys_sn,
+        )
     
     async def initialize(self) -> bool:
         """Initialize or re-initialize the client."""
@@ -51,25 +56,4 @@ class ByteWattClient:
             charge_cap=charge_cap,
             discharge_time_control=discharge_time_control,
             grid_charging=grid_charging
-        )
-
-    async def get_grid_feedin_settings(self):
-        """Get grid feed-in settings."""
-        return await self.api_client.async_get_grid_feedin_settings()
-
-    async def update_grid_feedin_settings(self,
-                                          enabled: bool = None,
-                                          cutoff_soc: float = None,
-                                          slot_index: int = None,
-                                          slot_start: str = None,
-                                          slot_end: str = None,
-                                          slot_power: int = None) -> bool:
-        """Update grid feed-in settings."""
-        return await self.api_client.async_update_grid_feedin_settings(
-            enabled=enabled,
-            cutoff_soc=cutoff_soc,
-            slot_index=slot_index,
-            slot_start=slot_start,
-            slot_end=slot_end,
-            slot_power=slot_power,
         )

--- a/custom_components/bytewatt/bytewatt_client.py
+++ b/custom_components/bytewatt/bytewatt_client.py
@@ -45,7 +45,9 @@ class ByteWattClient:
                                     minimum_soc: int = None,
                                     charge_cap: int = None,
                                     discharge_time_control: bool = None,
-                                    grid_charging: bool = None) -> bool:
+                                    grid_charging: bool = None,
+                                    charge_power: int = None,
+                                    discharge_power: int = None) -> bool:
         """Update battery settings."""
         return await self.api_client.async_update_battery_settings(
             discharge_start_time=discharge_start_time,
@@ -55,5 +57,28 @@ class ByteWattClient:
             minimum_soc=minimum_soc,
             charge_cap=charge_cap,
             discharge_time_control=discharge_time_control,
-            grid_charging=grid_charging
+            grid_charging=grid_charging,
+            charge_power=charge_power,
+            discharge_power=discharge_power,
+        )
+
+    async def get_grid_feedin_settings(self):
+        """Get grid feed-in settings."""
+        return await self.api_client.async_get_grid_feedin_settings()
+
+    async def update_grid_feedin_settings(self,
+                                          enabled: bool = None,
+                                          cutoff_soc: float = None,
+                                          slot_index: int = None,
+                                          slot_start: str = None,
+                                          slot_end: str = None,
+                                          slot_power: int = None) -> bool:
+        """Update grid feed-in settings."""
+        return await self.api_client.async_update_grid_feedin_settings(
+            enabled=enabled,
+            cutoff_soc=cutoff_soc,
+            slot_index=slot_index,
+            slot_start=slot_start,
+            slot_end=slot_end,
+            slot_power=slot_power,
         )

--- a/custom_components/bytewatt/config_flow.py
+++ b/custom_components/bytewatt/config_flow.py
@@ -5,18 +5,29 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.selector import (
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+    SelectOptionDict,
+)
 
 from .bytewatt_client import ByteWattClient
 from .const import (
-    DOMAIN, 
-    CONF_USERNAME, 
+    DOMAIN,
+    CONF_USERNAME,
     CONF_PASSWORD,
     CONF_SCAN_INTERVAL,
+    CONF_HOST_SYSTEM_ID,
+    CONF_HOST_SYS_SN,
     DEFAULT_SCAN_INTERVAL,
-    MIN_SCAN_INTERVAL
+    MIN_SCAN_INTERVAL,
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+SYSTEM_LIST_ENDPOINT = "api/stable/home/getCustomMenuEssList?inverterMode=0"
+
 
 class ByteWattConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Byte-Watt."""
@@ -24,24 +35,45 @@ class ByteWattConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
+    def __init__(self):
+        self._user_input = {}
+        self._client = None
+        self._inverters = []
+
     async def async_step_user(self, user_input=None):
-        """Handle the initial step."""
+        """Handle the initial credentials step."""
         errors = {}
 
         if user_input is not None:
-            # Validate the credentials
-            client = ByteWattClient(self.hass, user_input[CONF_USERNAME], user_input[CONF_PASSWORD])
+            client = ByteWattClient(
+                self.hass, user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
+            )
             success = await client.initialize()
 
             if success:
-                return self.async_create_entry(
-                    title=f"Byte-Watt ({user_input[CONF_USERNAME]})",
-                    data=user_input,
-                )
+                self._client = client
+                self._user_input = user_input
+
+                # Fetch inverter list to decide whether to show selection step
+                inverters = await self._fetch_inverters()
+                self._inverters = inverters
+
+                if len(inverters) > 1:
+                    # Multiple inverters — ask user to pick the Host
+                    return await self.async_step_select_inverter()
+                elif len(inverters) == 1:
+                    # Single inverter — use it automatically, no need to ask
+                    inv = inverters[0]
+                    self._user_input[CONF_HOST_SYSTEM_ID] = inv["systemId"]
+                    self._user_input[CONF_HOST_SYS_SN] = inv["sysSn"]
+                    return self._create_entry()
+                else:
+                    # Couldn't fetch inverter list — continue without it
+                    _LOGGER.warning("Could not fetch inverter list during setup")
+                    return self._create_entry()
             else:
                 errors["base"] = "auth"
 
-        # Show the form
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema(
@@ -56,10 +88,76 @@ class ByteWattConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    async def async_step_select_inverter(self, user_input=None):
+        """Let the user pick which inverter is the Host for Grid Feed-in control."""
+        errors = {}
+
+        if user_input is not None:
+            selected_id = user_input[CONF_HOST_SYSTEM_ID]
+            # Find the matching sysSn
+            sys_sn = next(
+                (i["sysSn"] for i in self._inverters if i["systemId"] == selected_id),
+                ""
+            )
+            self._user_input[CONF_HOST_SYSTEM_ID] = selected_id
+            self._user_input[CONF_HOST_SYS_SN] = sys_sn
+            return self._create_entry()
+
+        # Build dropdown options — label shows sysSn + remark if available
+        options = []
+        default = None
+        for inv in self._inverters:
+            system_id = inv.get("systemId", "")
+            sys_sn = inv.get("sysSn", system_id)
+            remark = inv.get("remark", "")
+            label = f"{sys_sn} ({remark})" if remark else sys_sn
+            options.append(SelectOptionDict(value=system_id, label=label))
+            # Pre-select the one labelled Master/Host if present
+            if default is None:
+                remark_lower = remark.lower()
+                if "master" in remark_lower or "host" in remark_lower:
+                    default = system_id
+
+        if default is None and options:
+            default = options[0]["value"]
+
+        return self.async_show_form(
+            step_id="select_inverter",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_HOST_SYSTEM_ID, default=default): SelectSelector(
+                        SelectSelectorConfig(
+                            options=options,
+                            mode=SelectSelectorMode.LIST,
+                        )
+                    ),
+                }
+            ),
+            description_placeholders={
+                "count": str(len(self._inverters)),
+            },
+            errors=errors,
+        )
+
+    def _create_entry(self):
+        return self.async_create_entry(
+            title=f"Byte-Watt ({self._user_input[CONF_USERNAME]})",
+            data=self._user_input,
+        )
+
+    async def _fetch_inverters(self) -> list:
+        """Fetch the inverter list via the API."""
+        try:
+            response = await self._client.api_client._async_get(SYSTEM_LIST_ENDPOINT)
+            if response and response.get("code") == 200:
+                return response.get("data") or []
+        except Exception as ex:
+            _LOGGER.error("Error fetching inverter list: %s", ex)
+        return []
+
     @staticmethod
     @callback
     def async_get_options_flow(config_entry):
-        """Get the options flow for this handler."""
         return ByteWattOptionsFlowHandler(config_entry)
 
 
@@ -67,7 +165,6 @@ class ByteWattOptionsFlowHandler(config_entries.OptionsFlow):
     """Handle options for Byte-Watt."""
 
     def __init__(self, config_entry):
-        """Initialize options flow."""
         self.config_entry = config_entry
 
     async def async_step_init(self, user_input=None):

--- a/custom_components/bytewatt/const.py
+++ b/custom_components/bytewatt/const.py
@@ -90,3 +90,15 @@ RECENT_DATA_THRESHOLD = 300  # 5 minutes in seconds
 STALE_DATA_THRESHOLD = 3600  # 1 hour in seconds
 AUTO_RECONNECT_INTERVAL_HOURS = 24  # 24 hours
 HTTPS_PORT = 443
+
+# Grid Feed-in Control constants
+SERVICE_SET_GRID_FEEDIN_ENABLED = "set_grid_feedin_enabled"
+SERVICE_SET_GRID_FEEDIN_CUTOFF_SOC = "set_grid_feedin_cutoff_soc"
+SERVICE_UPDATE_GRID_FEEDIN_SLOT = "update_grid_feedin_slot"
+
+ATTR_FEEDIN_ENABLED = "feedin_enabled"
+ATTR_FEEDIN_CUTOFF_SOC = "feedin_cutoff_soc"
+ATTR_FEEDIN_SLOT = "slot"
+ATTR_FEEDIN_START = "start_time"
+ATTR_FEEDIN_END = "end_time"
+ATTR_FEEDIN_POWER = "power_watts"

--- a/custom_components/bytewatt/const.py
+++ b/custom_components/bytewatt/const.py
@@ -102,3 +102,7 @@ ATTR_FEEDIN_SLOT = "slot"
 ATTR_FEEDIN_START = "start_time"
 ATTR_FEEDIN_END = "end_time"
 ATTR_FEEDIN_POWER = "power_watts"
+
+# Host inverter selection
+CONF_HOST_SYSTEM_ID = "host_system_id"
+CONF_HOST_SYS_SN = "host_sys_sn"

--- a/custom_components/bytewatt/coordinator.py
+++ b/custom_components/bytewatt/coordinator.py
@@ -177,6 +177,12 @@ class ByteWattDataUpdateCoordinator(DataUpdateCoordinator):
                     await self.client.api_client.async_get_battery_settings()
             except Exception as ex:
                 _LOGGER.warning(f"Failed to fetch battery settings: {ex}")
+
+            # Get grid feed-in settings (don't fail if this fails)
+            try:
+                await self.client.api_client.async_get_grid_feedin_settings()
+            except Exception as ex:
+                _LOGGER.warning(f"Failed to fetch grid feed-in settings: {ex}")
             
             # If we got battery data, update our cached version and last successful time
             if battery_data:

--- a/custom_components/bytewatt/grid_feedin.py
+++ b/custom_components/bytewatt/grid_feedin.py
@@ -1,0 +1,288 @@
+"""Grid Feed-in Control entities for the Byte-Watt integration.
+
+Entities write to the PendingStore instead of calling the API directly.
+The Submit Settings button in pending.py pushes everything to the API.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import time
+from typing import Any, Optional
+
+from homeassistant.components.number import NumberDeviceClass, NumberEntity
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.components.time import TimeEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import ByteWattDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+SLOT = 0  # Only manage Time Period 1
+
+
+def _cache(hass, entry_id):
+    try:
+        client = hass.data[DOMAIN][entry_id]["client"]
+        return getattr(client.api_client, "_grid_feedin_cache", None)
+    except Exception:
+        return None
+
+
+def _parse_time(time_str: str) -> Optional[time]:
+    try:
+        if time_str and ":" in time_str:
+            h, m = time_str.split(":", 1)
+            return time(int(h), int(m))
+    except (ValueError, AttributeError):
+        pass
+    return None
+
+
+def _fmt_time(t: time) -> str:
+    return f"{t.hour:02d}:{t.minute:02d}"
+
+
+class _FeedInBase(CoordinatorEntity):
+    def __init__(self, coordinator: ByteWattDataUpdateCoordinator, config_entry: ConfigEntry):
+        super().__init__(coordinator)
+        self._config_entry = config_entry
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self._config_entry.entry_id)},
+            "name": "ByteWatt Battery System",
+            "manufacturer": "ByteWatt",
+            "model": "Battery Management System",
+            "sw_version": "1.0.0",
+        }
+
+    @property
+    def available(self) -> bool:
+        return _cache(self.hass, self._config_entry.entry_id) is not None
+
+
+class ByteWattGridFeedInSwitch(_FeedInBase, SwitchEntity):
+    def __init__(self, coordinator, config_entry):
+        super().__init__(coordinator, config_entry)
+        self._attr_name = "Grid Feed-in Function"
+        self._attr_unique_id = f"{config_entry.entry_id}_grid_feedin_enabled"
+        self._attr_icon = "mdi:transmission-tower-export"
+        self._attr_entity_category = EntityCategory.CONFIG
+
+    @property
+    def is_on(self) -> Optional[bool]:
+        from .pending import get_pending
+        pending = get_pending(self.hass, self._config_entry.entry_id)
+        if pending is not None:
+            val = pending.get_feedin("enabled")
+            if val is not None:
+                return bool(val)
+        c = _cache(self.hass, self._config_entry.entry_id)
+        return c.enabled if c else None
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        await self._stage(True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        await self._stage(False)
+
+    async def _stage(self, state: bool) -> None:
+        from .pending import get_pending
+        pending = get_pending(self.hass, self._config_entry.entry_id)
+        if pending is not None:
+            pending.set_feedin(enabled=state)
+            _LOGGER.debug("Staged grid feed-in enabled=%s (pending submit)", state)
+            self.async_write_ha_state()
+        else:
+            _LOGGER.error("No pending store found for grid feed-in switch")
+
+
+class ByteWattGridFeedInCutoffSOC(_FeedInBase, NumberEntity):
+    def __init__(self, coordinator, config_entry):
+        super().__init__(coordinator, config_entry)
+        self._attr_name = "Grid Feed-in Discharging Cutoff SOC"
+        self._attr_unique_id = f"{config_entry.entry_id}_grid_feedin_cutoff_soc"
+        self._attr_icon = "mdi:battery-arrow-down"
+        self._attr_entity_category = EntityCategory.CONFIG
+        self._attr_native_min_value = 0
+        self._attr_native_max_value = 100
+        self._attr_native_step = 1
+        self._attr_native_unit_of_measurement = "%"
+        self._attr_device_class = NumberDeviceClass.BATTERY
+
+    @property
+    def native_value(self) -> Optional[float]:
+        from .pending import get_pending
+        pending = get_pending(self.hass, self._config_entry.entry_id)
+        if pending is not None:
+            val = pending.get_feedin("cutoff_soc")
+            if val is not None:
+                return float(val)
+        c = _cache(self.hass, self._config_entry.entry_id)
+        return float(c.battery_feed_cutoff_soc) if c else None
+
+    async def async_set_native_value(self, value: float) -> None:
+        from .pending import get_pending
+        pending = get_pending(self.hass, self._config_entry.entry_id)
+        if pending is not None:
+            pending.set_feedin(cutoff_soc=value)
+            _LOGGER.debug("Staged grid feed-in cutoff_soc=%s (pending submit)", value)
+            self.async_write_ha_state()
+        else:
+            _LOGGER.error("No pending store found for grid feed-in cutoff SOC")
+
+
+class ByteWattGridFeedInSlotPower(_FeedInBase, NumberEntity):
+    def __init__(self, coordinator, config_entry):
+        super().__init__(coordinator, config_entry)
+        self._attr_name = "Grid Feed-in Time1 Power"
+        self._attr_unique_id = f"{config_entry.entry_id}_grid_feedin_slot0_power"
+        self._attr_icon = "mdi:lightning-bolt"
+        self._attr_entity_category = EntityCategory.CONFIG
+        self._attr_native_min_value = 0
+        self._attr_native_max_value = 20000
+        self._attr_native_step = 100
+        self._attr_native_unit_of_measurement = "W"
+        self._attr_device_class = NumberDeviceClass.POWER
+
+    @property
+    def available(self) -> bool:
+        c = _cache(self.hass, self._config_entry.entry_id)
+        return bool(c) and len(c.slots) > SLOT
+
+    @property
+    def native_value(self) -> Optional[float]:
+        from .pending import get_pending
+        pending = get_pending(self.hass, self._config_entry.entry_id)
+        if pending is not None:
+            val = pending.get_feedin_slot(SLOT, "slot_power")
+            if val is not None:
+                return float(val)
+        c = _cache(self.hass, self._config_entry.entry_id)
+        if not c or len(c.slots) <= SLOT:
+            return None
+        return float(c.slots[SLOT].feed_power)
+
+    async def async_set_native_value(self, value: float) -> None:
+        from .pending import get_pending
+        pending = get_pending(self.hass, self._config_entry.entry_id)
+        if pending is not None:
+            pending.set_feedin_slot(SLOT, power=int(value))
+            _LOGGER.debug("Staged grid feed-in Time1 power=%s (pending submit)", int(value))
+            self.async_write_ha_state()
+        else:
+            _LOGGER.error("No pending store found for grid feed-in slot power")
+
+
+class ByteWattGridFeedInSlotStartTime(_FeedInBase, TimeEntity):
+    def __init__(self, coordinator, config_entry):
+        super().__init__(coordinator, config_entry)
+        self._attr_name = "Grid Feed-in Time1 Start"
+        self._attr_unique_id = f"{config_entry.entry_id}_grid_feedin_slot0_start"
+        self._attr_icon = "mdi:clock-start"
+        self._attr_entity_category = EntityCategory.CONFIG
+
+    @property
+    def available(self) -> bool:
+        c = _cache(self.hass, self._config_entry.entry_id)
+        return bool(c) and len(c.slots) > SLOT
+
+    @property
+    def native_value(self) -> Optional[time]:
+        from .pending import get_pending
+        pending = get_pending(self.hass, self._config_entry.entry_id)
+        if pending is not None:
+            val = pending.get_feedin_slot(SLOT, "slot_start")
+            if val is not None:
+                return _parse_time(val)
+        c = _cache(self.hass, self._config_entry.entry_id)
+        if not c or len(c.slots) <= SLOT:
+            return None
+        return _parse_time(c.slots[SLOT].start)
+
+    async def async_set_value(self, value: time) -> None:
+        from .pending import get_pending
+        pending = get_pending(self.hass, self._config_entry.entry_id)
+        if pending is not None:
+            pending.set_feedin_slot(SLOT, start=_fmt_time(value))
+            _LOGGER.debug("Staged grid feed-in Time1 start=%s (pending submit)", _fmt_time(value))
+            self.async_write_ha_state()
+        else:
+            _LOGGER.error("No pending store found for grid feed-in slot start")
+
+
+class ByteWattGridFeedInSlotEndTime(_FeedInBase, TimeEntity):
+    def __init__(self, coordinator, config_entry):
+        super().__init__(coordinator, config_entry)
+        self._attr_name = "Grid Feed-in Time1 End"
+        self._attr_unique_id = f"{config_entry.entry_id}_grid_feedin_slot0_end"
+        self._attr_icon = "mdi:clock-end"
+        self._attr_entity_category = EntityCategory.CONFIG
+
+    @property
+    def available(self) -> bool:
+        c = _cache(self.hass, self._config_entry.entry_id)
+        return bool(c) and len(c.slots) > SLOT
+
+    @property
+    def native_value(self) -> Optional[time]:
+        from .pending import get_pending
+        pending = get_pending(self.hass, self._config_entry.entry_id)
+        if pending is not None:
+            val = pending.get_feedin_slot(SLOT, "slot_end")
+            if val is not None:
+                return _parse_time(val)
+        c = _cache(self.hass, self._config_entry.entry_id)
+        if not c or len(c.slots) <= SLOT:
+            return None
+        return _parse_time(c.slots[SLOT].end)
+
+    async def async_set_value(self, value: time) -> None:
+        from .pending import get_pending
+        pending = get_pending(self.hass, self._config_entry.entry_id)
+        if pending is not None:
+            pending.set_feedin_slot(SLOT, end=_fmt_time(value))
+            _LOGGER.debug("Staged grid feed-in Time1 end=%s (pending submit)", _fmt_time(value))
+            self.async_write_ha_state()
+        else:
+            _LOGGER.error("No pending store found for grid feed-in slot end")
+
+
+async def async_setup_switch_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]["coordinator"]
+    async_add_entities([ByteWattGridFeedInSwitch(coordinator, config_entry)])
+
+
+async def async_setup_number_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]["coordinator"]
+    async_add_entities([
+        ByteWattGridFeedInCutoffSOC(coordinator, config_entry),
+        ByteWattGridFeedInSlotPower(coordinator, config_entry),
+    ])
+
+
+async def async_setup_time_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]["coordinator"]
+    async_add_entities([
+        ByteWattGridFeedInSlotStartTime(coordinator, config_entry),
+        ByteWattGridFeedInSlotEndTime(coordinator, config_entry),
+    ])

--- a/custom_components/bytewatt/models.py
+++ b/custom_components/bytewatt/models.py
@@ -15,7 +15,6 @@ class SoCData:
 
     @classmethod
     def from_api_response(cls, data: Dict[str, Any]) -> "SoCData":
-        """Create a SoCData instance from an API response."""
         return cls(
             soc=data.get("soc", 0),
             grid_consumption=data.get("gridConsumption", 0),
@@ -41,7 +40,6 @@ class GridData:
 
     @classmethod
     def from_api_response(cls, data: Dict[str, Any]) -> "GridData":
-        """Create a GridData instance from an API response."""
         return cls(
             total_solar_generation=data.get("Total_Solar_Generation", 0),
             total_feed_in=data.get("Total_Feed_In", 0),
@@ -55,162 +53,317 @@ class GridData:
         )
 
 
+# ---------------------------------------------------------------------------
+# New Cycle Strategy models — matches getCycleStrategy / setCycleStrategy
+# ---------------------------------------------------------------------------
+
 @dataclass
-class BatterySettings:
-    """Represents battery settings."""
-    grid_charge: int = 1
-    ctr_dis: int = 1
-    bat_use_cap: int = 6  # Minimum remaining SOC
-    time_chaf1a: str = "14:30"  # Charge start time
-    time_chae1a: str = "16:00"  # Charge end time
-    time_chaf2a: str = "00:00"
-    time_chae2a: str = "00:00"
-    time_disf1a: str = "16:00"  # Discharge start time
-    time_dise1a: str = "23:00"  # Discharge end time
-    time_disf2a: str = "06:00"
-    time_dise2a: str = "10:00"
-    bat_high_cap: str = "100"
-    last_updated: Optional[str] = None
-    
-    # Weekend settings
-    time_cha_fwe1a: str = "00:00"
-    time_cha_ewe1a: str = "00:00"
-    time_cha_fwe2a: str = "00:00"
-    time_cha_ewe2a: str = "00:00"
-    time_dis_fwe1a: str = "00:00"
-    time_dis_ewe1a: str = "00:00"
-    time_dis_fwe2a: str = "00:00"
-    time_dis_ewe2a: str = "00:00"
-    
-    # Peak settings
-    peak_s1a: str = "00:00"
-    peak_e1a: str = "00:00"
-    peak_s2a: str = "00:00"
-    peak_e2a: str = "00:00"
-    
-    # Fill settings
-    fill_s1a: str = "00:00"
-    fill_e1a: str = "00:00"
-    fill_s2a: str = "00:00"
-    fill_e2a: str = "00:00"
-    
-    # Offset settings
-    pm_offset_s1a: str = "00:00"
-    pm_offset_e1a: str = "00:00"
-    pm_offset_s2a: str = "00:00"
-    pm_offset_e2a: str = "00:00"
-    
-    # Additional fields
-    additional_fields: Dict[str, Any] = field(default_factory=dict)
-    
+class ChargeSlot:
+    """One charge time slot."""
+    begin_time: str = "00:00"
+    end_time: str = "00:00"
+    charge_limit: float = 100.0    # Charging cutoff SOC %
+    charge_power: int = 8000       # W
+    sort: int = 1
+    weeks: List[int] = field(default_factory=lambda: [7, 1, 2, 3, 4, 5, 6])
+    feed_mode: int = 0
+    equip_group_id: int = 0
+    feed_power: int = 0
+
     @classmethod
-    def from_api_response(cls, data: Dict[str, Any]) -> "BatterySettings":
-        """Create a BatterySettings instance from the new API response."""
-        settings = cls(
-            grid_charge=data.get("gridCharge", 1),
-            ctr_dis=data.get("ctrDis", 1),
-            bat_use_cap=int(data.get("batUseCap", 6)),
-            time_chaf1a=data.get("timeChaf1", "14:30"),
-            time_chae1a=data.get("timeChae1", "16:00"),
-            time_chaf2a=data.get("timeChaf2", "00:00"),
-            time_chae2a=data.get("timeChae2", "00:00"),
-            time_disf1a=data.get("timeDisf1", "16:00"),
-            time_dise1a=data.get("timeDise1", "23:00"),
-            time_disf2a=data.get("timeDisf2", "06:00"),
-            time_dise2a=data.get("timeDise2", "10:00"),
-            bat_high_cap=str(data.get("batHighCap", 100)),
-            time_cha_fwe1a=data.get("time_cha_fwe1a", "00:00"),
-            time_cha_ewe1a=data.get("time_cha_ewe1a", "00:00"),
-            time_cha_fwe2a=data.get("time_cha_fwe2a", "00:00"),
-            time_cha_ewe2a=data.get("time_cha_ewe2a", "00:00"),
-            time_dis_fwe1a=data.get("time_dis_fwe1a", "00:00"),
-            time_dis_ewe1a=data.get("time_dis_ewe1a", "00:00"),
-            time_dis_fwe2a=data.get("time_dis_fwe2a", "00:00"),
-            time_dis_ewe2a=data.get("time_dis_ewe2a", "00:00"),
-            peak_s1a=data.get("peak_s1a", "00:00"),
-            peak_e1a=data.get("peak_e1a", "00:00"),
-            peak_s2a=data.get("peak_s2a", "00:00"),
-            peak_e2a=data.get("peak_e2a", "00:00"),
-            fill_s1a=data.get("fill_s1a", "00:00"),
-            fill_e1a=data.get("fill_e1a", "00:00"),
-            fill_s2a=data.get("fill_s2a", "00:00"),
-            fill_e2a=data.get("fill_e2a", "00:00"),
-            pm_offset_s1a=data.get("pm_offset_s1a", "00:00"),
-            pm_offset_e1a=data.get("pm_offset_e1a", "00:00"),
-            pm_offset_s2a=data.get("pm_offset_s2a", "00:00"),
-            pm_offset_e2a=data.get("pm_offset_e2a", "00:00"),
+    def from_api_response(cls, data: Dict[str, Any]) -> "ChargeSlot":
+        return cls(
+            begin_time=data.get("beginTime", "00:00"),
+            end_time=data.get("endTime", "00:00"),
+            charge_limit=float(data.get("chargeLimit", 100.0)),
+            charge_power=int(data.get("chargePower", 8000)),
+            sort=int(data.get("sort", 1)),
+            weeks=data.get("weeks", [7, 1, 2, 3, 4, 5, 6]),
+            feed_mode=int(data.get("feedMode", 0)),
+            equip_group_id=int(data.get("equipGroupId", 0)),
+            feed_power=int(data.get("feedPower", 0)),
         )
-        
-        # Store additional fields
-        additional_fields = {}
-        for field in [
-            "sys_sn", "ems_version", "charge_workdays", "bakbox_ver",
-            "charge_weekend", "grid_Charge_we", "bat_highcap_we",
-            "ctr_dis_we", "bat_usecap_we", "basic_mode_jp", "peace_mode_jp",
-            "vpp_mode_jp", "channel1", "control_mode1", "start_time1a", 
-            "end_time1a", "start_time1b", "end_time1b", "date1", 
-            "charge_soc1", "ups1", "switch_on1", "switch_off1", 
-            "delay1", "duration1", "pause1", "channel2", "control_mode2", 
-            "start_time2a", "end_time2a", "start_time2b", "end_time2b", 
-            "date2", "charge_soc2", "ups2", "switch_on2", "switch_off2", 
-            "delay2", "duration2", "pause2", "l1_priority", "l2_priority", 
-            "l3_priority", "l1_soc_limit", "l2_soc_limit", "l3_soc_limit", 
-            "charge_mode2", "charge_mode1", "backupbox", "minv", "mbat", 
-            "generator", "gc_output_mode", "generator_mode", "gc_soc_start", 
-            "gc_soc_end", "gc_time_start", "gc_time_end", "gc_charge_power", 
-            "gc_rated_power", "dg_cap", "dg_frequency", "gc_rate_percent", 
-            "chargingpile", "currentsetting", "chargingmode", "charging_pile_list", 
-            "chargingpile_control_open", "peak_fill_en", "peakvalue", "fillvalue", 
-            "delta", "pm_offset", "pm_max", "pm_offset_en", "stoinv_type", 
-            "loadcut_soc", "loadtied_soc", "ac_tied", "soc_50_flag", 
-            "auto_soccalib_en", "three_unbalance_en", "enable_current_set", 
-            "enable_obc_set", "upsReserve", "columnIsSow", "nmi", "state", 
-            "agent", "country_code", "register_dynamic_export", "register_type"
-        ]:
-            if field in data:
-                additional_fields[field] = data[field]
-        
-        settings.additional_fields = additional_fields
-        return settings
-    
+
     def to_dict(self) -> Dict[str, Any]:
-        """Convert settings to dictionary for API submissions using new API format."""
-        result = {
-            "id": "",  # Empty for all devices
-            "basicModeJp": None,
-            "peaceModeJp": None,
-            "vppModeJp": None,
-            "gridCharge": self.grid_charge,
-            "timeChaf1": self.time_chaf1a,
-            "timeChae1": self.time_chae1a,
-            "timeChaf2": self.time_chaf2a,
-            "timeChae2": self.time_chae2a,
-            "ctrDis": self.ctr_dis,
-            "timeDisf1": self.time_disf1a,
-            "timeDise1": self.time_dise1a,
-            "timeDisf2": self.time_disf2a,
-            "timeDise2": self.time_dise2a,
-            "batHighCap": float(self.bat_high_cap) if isinstance(self.bat_high_cap, str) else self.bat_high_cap,
-            "batUseCap": self.bat_use_cap,
-            "batCapRange": [5, 100],  # Default range
-            "isJapaneseDevice": False,
-            "upsReserveEnable": True,
-            "upsReserve": 1,
-            "mbat": "BW-BAT-10.1P",  # Default battery model
-            "chargeModeSetting": 0,
-            "loadcutoutEn": 0,
-            "cutoffSoc": 0,
-            "wakeupSoc": 0,
-            "timeChaMode": 0,
-            "hasBalconyModel": 0,
-            "balconyModel": None,
-            "timeExpLimW1": 800,
-            "timeExpLimW2": 800,
-            "isSiteDevice": None,
-            "isSupportOffGridSocControl": True,
+        return {
+            "beginTime": self.begin_time,
+            "endTime": self.end_time,
+            "chargeLimit": self.charge_limit,
+            "chargePower": self.charge_power,
+            "sort": self.sort,
+            "weeks": self.weeks,
+            "feedMode": self.feed_mode,
+            "equipGroupId": self.equip_group_id,
+            "feedPower": self.feed_power,
         }
-        
-        # Add additional fields
-        result.update(self.additional_fields)
-        
+
+
+@dataclass
+class DischargeSlot:
+    """One discharge time slot."""
+    begin_time: str = "00:00"
+    end_time: str = "00:00"
+    charge_limit: float = 10.0     # Discharging cutoff SOC %
+    charge_power: int = 10000      # Battery discharge power W
+    sort: int = 1
+    weeks: List[int] = field(default_factory=lambda: [7, 1, 2, 3, 4, 5, 6])
+    feed_mode: int = 0
+    equip_group_id: int = 0
+    feed_power: int = 0
+
+    @classmethod
+    def from_api_response(cls, data: Dict[str, Any]) -> "DischargeSlot":
+        return cls(
+            begin_time=data.get("beginTime", "00:00"),
+            end_time=data.get("endTime", "00:00"),
+            charge_limit=float(data.get("chargeLimit", 10.0)),
+            charge_power=int(data.get("chargePower", 10000)),
+            sort=int(data.get("sort", 1)),
+            weeks=data.get("weeks", [7, 1, 2, 3, 4, 5, 6]),
+            feed_mode=int(data.get("feedMode", 0)),
+            equip_group_id=int(data.get("equipGroupId", 0)),
+            feed_power=int(data.get("feedPower", 0)),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "beginTime": self.begin_time,
+            "endTime": self.end_time,
+            "chargeLimit": self.charge_limit,
+            "chargePower": self.charge_power,
+            "sort": self.sort,
+            "weeks": self.weeks,
+            "feedMode": self.feed_mode,
+            "equipGroupId": self.equip_group_id,
+            "feedPower": self.feed_power,
+        }
+
+
+@dataclass
+class CycleStrategy:
+    """
+    Battery cycle strategy — maps to getCycleStrategy / setCycleStrategy.
+
+    Replaces the old BatterySettings model.
+    Property aliases are provided so existing code that reads
+    bat_use_cap, grid_charge, ctr_dis, time_chaf1a etc. keeps working.
+    """
+    # Top-level flags
+    grid_charge_cycle: int = 1      # gridChargeCycle  (grid charging enabled)
+    ctr_dis_cycle: int = 1          # ctrDisCycle      (discharge time control)
+    bat_use_cap: float = 10.0       # batUseCap        (global discharging cutoff SOC)
+    execute_cycle_type: int = 0     # 0=every day, 1=every week
+    ups_reserve: int = 0
+    loadcutout_en: int = 0
+    cutoff_soc: int = 0
+    wakeup_soc: int = 0
+    is_support_discharge_soc: bool = True
+    is_support_charger_power: bool = True
+    poinv: int = 10000
+
+    # Time slot lists (Time1 only exposed in HA)
+    charge_slots: List[ChargeSlot] = field(default_factory=list)
+    discharge_slots: List[DischargeSlot] = field(default_factory=list)
+
+    # Raw data preserved for round-tripping unknown fields
+    raw_data: Dict[str, Any] = field(default_factory=dict)
+    last_updated: Optional[str] = None
+
+    # ------------------------------------------------------------------
+    # Compatibility aliases so switch.py / number.py / time.py keep working
+    # ------------------------------------------------------------------
+
+    @property
+    def grid_charge(self) -> int:
+        return self.grid_charge_cycle
+
+    @grid_charge.setter
+    def grid_charge(self, v: int) -> None:
+        self.grid_charge_cycle = v
+
+    @property
+    def ctr_dis(self) -> int:
+        return self.ctr_dis_cycle
+
+    @ctr_dis.setter
+    def ctr_dis(self, v: int) -> None:
+        self.ctr_dis_cycle = v
+
+    # Charge slot 0 time aliases
+    @property
+    def time_chaf1a(self) -> str:
+        return self.charge_slots[0].begin_time if self.charge_slots else "00:00"
+
+    @time_chaf1a.setter
+    def time_chaf1a(self, v: str) -> None:
+        if self.charge_slots:
+            self.charge_slots[0].begin_time = v
+
+    @property
+    def time_chae1a(self) -> str:
+        return self.charge_slots[0].end_time if self.charge_slots else "00:00"
+
+    @time_chae1a.setter
+    def time_chae1a(self, v: str) -> None:
+        if self.charge_slots:
+            self.charge_slots[0].end_time = v
+
+    # bat_high_cap alias → charge_slots[0].charge_limit
+    @property
+    def bat_high_cap(self) -> str:
+        if self.charge_slots:
+            return str(int(self.charge_slots[0].charge_limit))
+        return "100"
+
+    @bat_high_cap.setter
+    def bat_high_cap(self, v) -> None:
+        if self.charge_slots:
+            self.charge_slots[0].charge_limit = float(v)
+
+    # Discharge slot 0 time aliases
+    @property
+    def time_disf1a(self) -> str:
+        return self.discharge_slots[0].begin_time if self.discharge_slots else "00:00"
+
+    @time_disf1a.setter
+    def time_disf1a(self, v: str) -> None:
+        if self.discharge_slots:
+            self.discharge_slots[0].begin_time = v
+
+    @property
+    def time_dise1a(self) -> str:
+        return self.discharge_slots[0].end_time if self.discharge_slots else "00:00"
+
+    @time_dise1a.setter
+    def time_dise1a(self, v: str) -> None:
+        if self.discharge_slots:
+            self.discharge_slots[0].end_time = v
+
+    @classmethod
+    def from_api_response(cls, data: Dict[str, Any]) -> "CycleStrategy":
+        charge_slots = [
+            ChargeSlot.from_api_response(s)
+            for s in (data.get("dayChargeTimeList") or [])
+        ]
+        discharge_slots = [
+            DischargeSlot.from_api_response(s)
+            for s in (data.get("dayDischargeTimeList") or [])
+        ]
+        return cls(
+            grid_charge_cycle=int(data.get("gridChargeCycle", 1)),
+            ctr_dis_cycle=int(data.get("ctrDisCycle", 1)),
+            bat_use_cap=float(data.get("batUseCap", 10.0)),
+            execute_cycle_type=int(data.get("executeCycleType", 0)),
+            ups_reserve=int(data.get("upsReserve", 0)),
+            loadcutout_en=int(data.get("loadcutoutEn", 0)),
+            cutoff_soc=int(data.get("cutoffSoc", 0)),
+            wakeup_soc=int(data.get("wakeupSoc", 0)),
+            is_support_discharge_soc=bool(data.get("isSupportDischargeSoc", True)),
+            is_support_charger_power=bool(data.get("isSupportChargerPower", True)),
+            poinv=int(data.get("poinv", 10000)),
+            charge_slots=charge_slots,
+            discharge_slots=discharge_slots,
+            raw_data=data,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Build the PUT payload for setCycleStrategy."""
+        result = dict(self.raw_data)  # preserve unknown fields
+        result.update({
+            "id": "",
+            "batUseCap": self.bat_use_cap,
+            "upsReserve": self.ups_reserve,
+            "executeCycleType": self.execute_cycle_type,
+            "loadcutoutEn": self.loadcutout_en,
+            "wakeupSoc": self.wakeup_soc,
+            "cutoffSoc": self.cutoff_soc,
+            "gridChargeCycle": self.grid_charge_cycle,
+            "ctrDisCycle": self.ctr_dis_cycle,
+            "chargeTimeList": [s.to_dict() for s in self.charge_slots],
+            "dischargeTimeList": [s.to_dict() for s in self.discharge_slots],
+            "isSupportDischargeSoc": self.is_support_discharge_soc,
+            "isSupportChargerPower": self.is_support_charger_power,
+            "poinv": self.poinv,
+        })
         return result
+
+
+# Alias so any code that still imports BatterySettings keeps working
+BatterySettings = CycleStrategy
+
+
+# ---------------------------------------------------------------------------
+# Grid feed-in models (unchanged)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class GridFeedInSlot:
+    """One grid feed-in time slot."""
+    id: Optional[int] = None
+    sys_sn: str = ""
+    start: str = "00:00"
+    end: str = "00:00"
+    feed_power: int = 0
+    sort: int = 1
+
+    @classmethod
+    def from_api_response(cls, data: Dict[str, Any]) -> "GridFeedInSlot":
+        return cls(
+            id=data.get("id"),
+            sys_sn=data.get("sysSn", ""),
+            start=data.get("start", "00:00"),
+            end=data.get("end", "00:00"),
+            feed_power=int(data.get("feedPower", 0)),
+            sort=int(data.get("sort", 1)),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        d: Dict[str, Any] = {
+            "start": self.start,
+            "end": self.end,
+            "feedPower": self.feed_power,
+            "sort": self.sort,
+        }
+        if self.id is not None:
+            d["id"] = self.id
+        if self.sys_sn:
+            d["sysSn"] = self.sys_sn
+        return d
+
+
+@dataclass
+class GridFeedInSettings:
+    """Grid feed-in control settings."""
+    system_id: str = ""
+    battery_en: int = 1
+    battery_feed_cutoff_soc: float = 20.0
+    precharge_en: int = 0
+    slots: List[GridFeedInSlot] = field(default_factory=list)
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.battery_en)
+
+    @enabled.setter
+    def enabled(self, value: bool) -> None:
+        self.battery_en = 1 if value else 0
+
+    @classmethod
+    def from_api_response(cls, data: Dict[str, Any], system_id: str = "") -> "GridFeedInSettings":
+        slots = [GridFeedInSlot.from_api_response(s) for s in (data.get("feedStrategyVOList") or [])]
+        return cls(
+            system_id=system_id,
+            battery_en=int(data.get("batteryEn", 1)),
+            battery_feed_cutoff_soc=float(data.get("batteryFeedCutoffSoc", 20.0)),
+            precharge_en=int(data.get("prechargeEn", 0)),
+            slots=slots,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.system_id,
+            "batteryEn": self.battery_en,
+            "batteryFeedCutoffSoc": self.battery_feed_cutoff_soc,
+            "prechargeEn": self.precharge_en,
+            "feedStrategyDTOList": [s.to_dict() for s in self.slots],
+        }

--- a/custom_components/bytewatt/number.py
+++ b/custom_components/bytewatt/number.py
@@ -29,6 +29,8 @@ async def async_setup_entry(
     entities = [
         ByteWattChargeCapNumber(coordinator, config_entry),
         ByteWattMinimumSOCNumber(coordinator, config_entry),
+        ByteWattChargePowerNumber(coordinator, config_entry),
+        ByteWattDischargePowerNumber(coordinator, config_entry),
     ]
 
     async_add_entities(entities)
@@ -178,3 +180,104 @@ class ByteWattChargeCapNumber(ByteWattNumberEntity):
                 _LOGGER.error("No pending store found for charge cap")
         except Exception as ex:
             _LOGGER.error(f"Error staging charge cap to {value}%: {ex}")
+
+class ByteWattChargePowerNumber(ByteWattNumberEntity):
+    """Number entity for battery charge power rate."""
+
+    def __init__(
+        self, coordinator: ByteWattDataUpdateCoordinator, config_entry: ConfigEntry
+    ) -> None:
+        super().__init__(
+            coordinator=coordinator,
+            config_entry=config_entry,
+            name="Battery Charge Power",
+            unique_id="charge_power",
+            icon="mdi:battery-charging-high",
+            min_value=500,
+            max_value=10000,
+            step=100,
+            device_class=NumberDeviceClass.POWER,
+        )
+        self._attr_native_unit_of_measurement = "W"
+
+    @property
+    def native_value(self) -> Optional[float]:
+        try:
+            from .pending import get_pending
+            pending = get_pending(self.hass, self._config_entry.entry_id)
+            if pending is not None:
+                val = pending.get_battery("charge_power")
+                if val is not None:
+                    return float(val)
+            client = self.hass.data[DOMAIN][self._config_entry.entry_id]["client"]
+            if hasattr(client.api_client, "_settings_cache") and client.api_client._settings_cache:
+                settings = client.api_client._settings_cache
+                if settings.charge_slots:
+                    return float(settings.charge_slots[0].charge_power)
+        except (ValueError, TypeError, AttributeError) as ex:
+            _LOGGER.debug(f"Error getting charge power value: {ex}")
+        return None
+
+    async def async_set_native_value(self, value: float) -> None:
+        try:
+            from .pending import get_pending
+            pending = get_pending(self.hass, self._config_entry.entry_id)
+            if pending is not None:
+                pending.set_battery(charge_power=int(value))
+                _LOGGER.debug("Staged charge_power=%sW (pending submit)", int(value))
+                self.async_write_ha_state()
+            else:
+                _LOGGER.error("No pending store found for charge power")
+        except Exception as ex:
+            _LOGGER.error(f"Error staging charge power to {value}W: {ex}")
+
+
+class ByteWattDischargePowerNumber(ByteWattNumberEntity):
+    """Number entity for battery discharge power rate."""
+
+    def __init__(
+        self, coordinator: ByteWattDataUpdateCoordinator, config_entry: ConfigEntry
+    ) -> None:
+        super().__init__(
+            coordinator=coordinator,
+            config_entry=config_entry,
+            name="Battery Discharge Power",
+            unique_id="discharge_power",
+            icon="mdi:battery-minus",
+            min_value=500,
+            max_value=10000,
+            step=100,
+            device_class=NumberDeviceClass.POWER,
+        )
+        self._attr_native_unit_of_measurement = "W"
+
+    @property
+    def native_value(self) -> Optional[float]:
+        try:
+            from .pending import get_pending
+            pending = get_pending(self.hass, self._config_entry.entry_id)
+            if pending is not None:
+                val = pending.get_battery("discharge_power")
+                if val is not None:
+                    return float(val)
+            client = self.hass.data[DOMAIN][self._config_entry.entry_id]["client"]
+            if hasattr(client.api_client, "_settings_cache") and client.api_client._settings_cache:
+                settings = client.api_client._settings_cache
+                if settings.discharge_slots:
+                    return float(settings.discharge_slots[0].charge_power)
+        except (ValueError, TypeError, AttributeError) as ex:
+            _LOGGER.debug(f"Error getting discharge power value: {ex}")
+        return None
+
+    async def async_set_native_value(self, value: float) -> None:
+        try:
+            from .pending import get_pending
+            pending = get_pending(self.hass, self._config_entry.entry_id)
+            if pending is not None:
+                pending.set_battery(discharge_power=int(value))
+                _LOGGER.debug("Staged discharge_power=%sW (pending submit)", int(value))
+                self.async_write_ha_state()
+            else:
+                _LOGGER.error("No pending store found for discharge power")
+        except Exception as ex:
+            _LOGGER.error(f"Error staging discharge power to {value}W: {ex}")

--- a/custom_components/bytewatt/number.py
+++ b/custom_components/bytewatt/number.py
@@ -23,6 +23,9 @@ async def async_setup_entry(
     """Set up Byte-Watt number entities from a config entry."""
     coordinator = hass.data[DOMAIN][config_entry.entry_id]["coordinator"]
 
+    from .grid_feedin import async_setup_number_entry as _feedin_setup
+    await _feedin_setup(hass, config_entry, async_add_entities)
+
     entities = [
         ByteWattChargeCapNumber(coordinator, config_entry),
         ByteWattMinimumSOCNumber(coordinator, config_entry),
@@ -92,8 +95,14 @@ class ByteWattMinimumSOCNumber(ByteWattNumberEntity):
 
     @property
     def native_value(self) -> Optional[float]:
-        """Return the current minimum SOC value."""
+        """Return pending value if staged, else current API cache value."""
         try:
+            from .pending import get_pending
+            pending = get_pending(self.hass, self._config_entry.entry_id)
+            if pending is not None:
+                val = pending.get_battery("minimum_soc")
+                if val is not None:
+                    return float(val)
             client = self.hass.data[DOMAIN][self._config_entry.entry_id]["client"]
             if hasattr(client.api_client, "_settings_cache") and client.api_client._settings_cache:
                 settings = client.api_client._settings_cache
@@ -103,18 +112,18 @@ class ByteWattMinimumSOCNumber(ByteWattNumberEntity):
         return None
 
     async def async_set_native_value(self, value: float) -> None:
-        """Set the minimum SOC value."""
+        """Stage minimum SOC in pending store."""
         try:
-            client = self.hass.data[DOMAIN][self._config_entry.entry_id]["client"]
-            success = await client.update_battery_settings(minimum_soc=int(value))
-            if success:
-                _LOGGER.info(f"Successfully updated minimum SOC to {value}%")
-                # Trigger coordinator refresh to update other entities
-                await self.coordinator.async_request_refresh()
+            from .pending import get_pending
+            pending = get_pending(self.hass, self._config_entry.entry_id)
+            if pending is not None:
+                pending.set_battery(minimum_soc=int(value))
+                _LOGGER.debug("Staged minimum_soc=%s (pending submit)", int(value))
+                self.async_write_ha_state()
             else:
-                _LOGGER.error(f"Failed to update minimum SOC to {value}%")
+                _LOGGER.error("No pending store found for minimum SOC")
         except Exception as ex:
-            _LOGGER.error(f"Error setting minimum SOC to {value}%: {ex}")
+            _LOGGER.error(f"Error staging minimum SOC to {value}%: {ex}")
 
 
 class ByteWattChargeCapNumber(ByteWattNumberEntity):
@@ -139,8 +148,14 @@ class ByteWattChargeCapNumber(ByteWattNumberEntity):
 
     @property
     def native_value(self) -> Optional[float]:
-        """Return the current charge cap value."""
+        """Return pending value if staged, else current API cache value."""
         try:
+            from .pending import get_pending
+            pending = get_pending(self.hass, self._config_entry.entry_id)
+            if pending is not None:
+                val = pending.get_battery("charge_cap")
+                if val is not None:
+                    return float(val)
             client = self.hass.data[DOMAIN][self._config_entry.entry_id]["client"]
             if hasattr(client.api_client, "_settings_cache") and client.api_client._settings_cache:
                 settings = client.api_client._settings_cache
@@ -151,15 +166,15 @@ class ByteWattChargeCapNumber(ByteWattNumberEntity):
         return None
 
     async def async_set_native_value(self, value: float) -> None:
-        """Set the charge cap value."""
+        """Stage charge cap in pending store."""
         try:
-            client = self.hass.data[DOMAIN][self._config_entry.entry_id]["client"]
-            success = await client.update_battery_settings(charge_cap=int(value))
-            if success:
-                _LOGGER.info(f"Successfully updated charge cap to {value}%")
-                # Trigger coordinator refresh to update other entities
-                await self.coordinator.async_request_refresh()
+            from .pending import get_pending
+            pending = get_pending(self.hass, self._config_entry.entry_id)
+            if pending is not None:
+                pending.set_battery(charge_cap=int(value))
+                _LOGGER.debug("Staged charge_cap=%s (pending submit)", int(value))
+                self.async_write_ha_state()
             else:
-                _LOGGER.error(f"Failed to update charge cap to {value}%")
+                _LOGGER.error("No pending store found for charge cap")
         except Exception as ex:
-            _LOGGER.error(f"Error setting charge cap to {value}%: {ex}")
+            _LOGGER.error(f"Error staging charge cap to {value}%: {ex}")

--- a/custom_components/bytewatt/pending.py
+++ b/custom_components/bytewatt/pending.py
@@ -1,0 +1,214 @@
+"""Pending settings store and Submit button for the Byte-Watt integration.
+
+All setting entities write their changes here instead of calling the API
+immediately.  The ByteWattSubmitButton entity pushes everything to the API
+in one shot, then clears the pending store on success or discards it on
+failure (reverting entities to the last known-good API cache values).
+"""
+from __future__ import annotations
+
+import copy
+import logging
+from typing import Any, Dict, Optional
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import ByteWattDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Pending store — one instance per config entry, stored in hass.data
+# ---------------------------------------------------------------------------
+
+class PendingStore:
+    """Holds unsaved changes for battery and grid feed-in settings."""
+
+    def __init__(self):
+        # Battery settings pending changes — keyed by kwarg name used in
+        # client.update_battery_settings()
+        self._battery: Dict[str, Any] = {}
+
+        # Grid feed-in pending changes — mirrors the kwargs for
+        # client.update_grid_feedin_settings(), except slot changes are
+        # stored as a dict keyed by slot_index.
+        self._feedin: Dict[str, Any] = {}
+        self._feedin_slots: Dict[int, Dict[str, Any]] = {}
+
+    # --- battery ---
+
+    def set_battery(self, **kwargs) -> None:
+        """Stage a battery setting change."""
+        self._battery.update({k: v for k, v in kwargs.items() if v is not None})
+
+    def get_battery(self, key: str, default=None):
+        """Return a pending battery value if staged, else default."""
+        return self._battery.get(key, default)
+
+    def has_battery_pending(self) -> bool:
+        return bool(self._battery)
+
+    # --- grid feed-in ---
+
+    def set_feedin(self, enabled: bool = None, cutoff_soc: float = None) -> None:
+        """Stage a top-level grid feed-in change."""
+        if enabled is not None:
+            self._feedin["enabled"] = enabled
+        if cutoff_soc is not None:
+            self._feedin["cutoff_soc"] = cutoff_soc
+
+    def set_feedin_slot(self, slot_index: int,
+                        start: str = None, end: str = None, power: int = None) -> None:
+        """Stage a slot-level grid feed-in change."""
+        slot = self._feedin_slots.setdefault(slot_index, {})
+        if start is not None:
+            slot["slot_start"] = start
+        if end is not None:
+            slot["slot_end"] = end
+        if power is not None:
+            slot["slot_power"] = power
+
+    def get_feedin(self, key: str, default=None):
+        return self._feedin.get(key, default)
+
+    def get_feedin_slot(self, slot_index: int, key: str, default=None):
+        return self._feedin_slots.get(slot_index, {}).get(key, default)
+
+    def has_feedin_pending(self) -> bool:
+        return bool(self._feedin) or bool(self._feedin_slots)
+
+    def has_any_pending(self) -> bool:
+        return self.has_battery_pending() or self.has_feedin_pending()
+
+    # --- lifecycle ---
+
+    def clear(self) -> None:
+        """Clear all pending changes (called after successful submit)."""
+        self._battery.clear()
+        self._feedin.clear()
+        self._feedin_slots.clear()
+
+
+def get_pending(hass: HomeAssistant, entry_id: str) -> Optional[PendingStore]:
+    """Return the PendingStore for this config entry."""
+    try:
+        return hass.data[DOMAIN][entry_id]["pending"]
+    except (KeyError, TypeError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Submit button
+# ---------------------------------------------------------------------------
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the submit button platform."""
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]["coordinator"]
+    async_add_entities([ByteWattSubmitButton(coordinator, config_entry)])
+
+
+class ByteWattSubmitButton(CoordinatorEntity, ButtonEntity):
+    """Button that pushes all pending setting changes to the API."""
+
+    def __init__(
+        self,
+        coordinator: ByteWattDataUpdateCoordinator,
+        config_entry: ConfigEntry,
+    ) -> None:
+        super().__init__(coordinator)
+        self._config_entry = config_entry
+        self._attr_name = "Submit Settings"
+        self._attr_unique_id = f"{config_entry.entry_id}_submit_settings"
+        self._attr_icon = "mdi:content-save-check"
+        self._attr_entity_category = EntityCategory.CONFIG
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self._config_entry.entry_id)},
+            "name": "ByteWatt Battery System",
+            "manufacturer": "ByteWatt",
+            "model": "Battery Management System",
+            "sw_version": "1.0.0",
+        }
+
+    async def async_press(self) -> None:
+        """Push all pending changes to the API."""
+        entry_id = self._config_entry.entry_id
+        pending = get_pending(self.hass, entry_id)
+        client = self.hass.data[DOMAIN][entry_id]["client"]
+
+        if not pending or not pending.has_any_pending():
+            _LOGGER.info("Submit pressed but no pending changes")
+            return
+
+        # Snapshot pending in case we need to log what failed
+        battery_snapshot = dict(pending._battery)
+        feedin_snapshot = dict(pending._feedin)
+        feedin_slots_snapshot = {k: dict(v) for k, v in pending._feedin_slots.items()}
+
+        all_ok = True
+
+        # --- Battery settings ---
+        if pending.has_battery_pending():
+            _LOGGER.debug("Submitting battery settings: %s", battery_snapshot)
+            success = await client.update_battery_settings(**battery_snapshot)
+            if success:
+                _LOGGER.info("Battery settings submitted successfully")
+            else:
+                _LOGGER.error("Failed to submit battery settings: %s", battery_snapshot)
+                all_ok = False
+
+        # --- Grid feed-in settings ---
+        if pending.has_feedin_pending():
+            # Apply top-level changes
+            fi_kwargs: Dict[str, Any] = {}
+            if "enabled" in feedin_snapshot:
+                fi_kwargs["enabled"] = feedin_snapshot["enabled"]
+            if "cutoff_soc" in feedin_snapshot:
+                fi_kwargs["cutoff_soc"] = feedin_snapshot["cutoff_soc"]
+
+            if fi_kwargs:
+                _LOGGER.debug("Submitting grid feed-in top-level: %s", fi_kwargs)
+                success = await client.update_grid_feedin_settings(**fi_kwargs)
+                if not success:
+                    _LOGGER.error("Failed to submit grid feed-in settings: %s", fi_kwargs)
+                    all_ok = False
+
+            # Apply slot changes
+            for slot_index, slot_kwargs in feedin_slots_snapshot.items():
+                _LOGGER.debug("Submitting grid feed-in slot %d: %s", slot_index, slot_kwargs)
+                success = await client.update_grid_feedin_settings(
+                    slot_index=slot_index, **slot_kwargs
+                )
+                if not success:
+                    _LOGGER.error(
+                        "Failed to submit grid feed-in slot %d: %s", slot_index, slot_kwargs
+                    )
+                    all_ok = False
+
+        if all_ok:
+            # Clear pending — API caches now hold the truth
+            pending.clear()
+            _LOGGER.info("All settings submitted successfully, pending store cleared")
+        else:
+            # Discard pending — revert to last known good API cache values
+            pending.clear()
+            _LOGGER.warning(
+                "One or more settings failed to submit — pending changes discarded, "
+                "entities will revert to last known good values"
+            )
+
+        # Refresh coordinator so all entities re-read from the API cache
+        await self.coordinator.async_request_refresh()

--- a/custom_components/bytewatt/services.yaml
+++ b/custom_components/bytewatt/services.yaml
@@ -1,17 +1,13 @@
-# Service definitions for the Byte-Watt integration
-
 force_reconnect:
   name: Force Reconnect
   description: >-
     Force the ByteWatt integration to reconnect to the API when it appears to be stuck.
-    Use this service if your ByteWatt integration has stopped updating and shows stale data.
     This will reset the client connection, authenticate again, and refresh all sensor data.
 
 health_check:
   name: Health Check
   description: >-
     Run a comprehensive health check on the ByteWatt integration.
-    This will check network connectivity, authentication, and API accessibility.
     Results will be displayed in a persistent notification.
   fields:
     entry_id:
@@ -26,11 +22,10 @@ toggle_diagnostics:
   name: Toggle Diagnostics
   description: >-
     Enable or disable detailed diagnostic logging for the ByteWatt integration.
-    When enabled, detailed logs will be collected about API operations, errors, and recovery attempts.
   fields:
     enable:
       name: Enable
-      description: Set to true to enable diagnostics, false to disable (toggles current state if not provided)
+      description: Set to true to enable diagnostics, false to disable
       required: false
       example: true
       selector:
@@ -178,14 +173,70 @@ update_battery_settings:
           step: 1
           unit_of_measurement: "%"
 
-force_reconnect:
-  name: Force Reconnect
-  description: Force reconnection to the ByteWatt API
+set_grid_feedin_enabled:
+  name: Set Grid Feed-in Enabled
+  description: Enable or disable the Grid Feed-in Function
+  fields:
+    feedin_enabled:
+      name: Enabled
+      description: Set to true to enable, false to disable
+      required: true
+      example: true
+      selector:
+        boolean:
 
-health_check:
-  name: Health Check
-  description: Run a comprehensive health check of the ByteWatt integration
+set_grid_feedin_cutoff_soc:
+  name: Set Grid Feed-in Cutoff SOC
+  description: Set the discharging cutoff state-of-charge for grid feed-in
+  fields:
+    feedin_cutoff_soc:
+      name: Cutoff SOC
+      description: Battery percentage at which grid feed-in stops discharging (0-100%)
+      required: true
+      example: 20
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+          unit_of_measurement: "%"
 
-toggle_diagnostics:
-  name: Toggle Diagnostics
-  description: Enable or disable diagnostic logging for the ByteWatt integration
+update_grid_feedin_slot:
+  name: Update Grid Feed-in Slot
+  description: Update the grid feed-in Time1 slot (start time, end time, and/or power).
+  fields:
+    slot:
+      name: Slot Number
+      description: Time slot number (always 1 for Time Period 1)
+      required: true
+      example: 1
+      selector:
+        number:
+          min: 1
+          max: 1
+          step: 1
+    start_time:
+      name: Start Time
+      description: Slot start time (HH:MM)
+      required: false
+      example: "17:00"
+      selector:
+        time: {}
+    end_time:
+      name: End Time
+      description: Slot end time (HH:MM)
+      required: false
+      example: "21:00"
+      selector:
+        time: {}
+    power_watts:
+      name: Grid Feed-in Power (W)
+      description: Maximum grid feed-in power in watts
+      required: false
+      example: 4000
+      selector:
+        number:
+          min: 0
+          max: 20000
+          step: 100
+          unit_of_measurement: "W"

--- a/custom_components/bytewatt/strings.json
+++ b/custom_components/bytewatt/strings.json
@@ -1,0 +1,27 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Byte-Watt Login",
+        "data": {
+          "username": "Username",
+          "password": "Password",
+          "scan_interval": "Scan Interval (seconds)"
+        }
+      },
+      "select_inverter": {
+        "title": "Select Host Inverter",
+        "description": "Multiple inverters were found on your account. Please select the Host inverter to use for Grid Feed-in control.",
+        "data": {
+          "host_system_id": "Multiple inverters found — please select the Host inverter for controls"
+        }
+      }
+    },
+    "error": {
+      "auth": "Invalid credentials. Please check your username and password."
+    },
+    "abort": {
+      "already_configured": "This Byte-Watt account is already configured."
+    }
+  }
+}

--- a/custom_components/bytewatt/switch.py
+++ b/custom_components/bytewatt/switch.py
@@ -23,6 +23,9 @@ async def async_setup_entry(
     """Set up Byte-Watt switch entities from a config entry."""
     coordinator = hass.data[DOMAIN][config_entry.entry_id]["coordinator"]
 
+    from .grid_feedin import async_setup_switch_entry as _feedin_setup
+    await _feedin_setup(hass, config_entry, async_add_entities)
+
     entities = [
         ByteWattGridChargeSwitch(coordinator, config_entry),
         ByteWattDischargeControlSwitch(coordinator, config_entry),
@@ -65,14 +68,22 @@ class ByteWattSwitchEntity(CoordinatorEntity, SwitchEntity):
 
     @property
     def is_on(self) -> Optional[bool]:
-        """Return true if the switch is on."""
+        """Return true if the switch is on, checking pending store first."""
         try:
+            from .pending import get_pending
+            pending = get_pending(self.hass, self._config_entry.entry_id)
+            # Check pending store first
+            pending_key = "discharge_time_control" if self._attribute == "ctr_dis" else "grid_charging"
+            if pending is not None:
+                pending_val = pending.get_battery(pending_key)
+                if pending_val is not None:
+                    return bool(pending_val)
+            # Fall back to API cache
             client = self.hass.data[DOMAIN][self._config_entry.entry_id]["client"]
             if hasattr(client.api_client, "_settings_cache") and client.api_client._settings_cache:
                 settings = client.api_client._settings_cache
                 value = getattr(settings, self._attribute, None)
                 if value is not None:
-                    # Convert API integer (0/1) to boolean
                     return bool(int(value))
         except (ValueError, TypeError, AttributeError) as ex:
             _LOGGER.debug(f"Error getting {self._attr_name} state: {ex}")
@@ -118,24 +129,18 @@ class ByteWattDischargeControlSwitch(ByteWattSwitchEntity):
         )
 
     async def _async_set_state(self, state: bool) -> None:
-        """Set the discharge control state."""
+        """Stage the discharge control state in pending store."""
         try:
-            client = self.hass.data[DOMAIN][self._config_entry.entry_id]["client"]
-            
-            # Use the client's update method with the discharge_time_control parameter
-            success = await client.update_battery_settings(discharge_time_control=state)
-            
-            if success:
-                action = "enabled" if state else "disabled"
-                _LOGGER.info(f"Successfully {action} discharge time control")
-                # Trigger coordinator refresh to update other entities
-                await self.coordinator.async_request_refresh()
+            from .pending import get_pending
+            pending = get_pending(self.hass, self._config_entry.entry_id)
+            if pending is not None:
+                pending.set_battery(discharge_time_control=state)
+                _LOGGER.debug("Staged discharge_time_control=%s (pending submit)", state)
+                self.async_write_ha_state()
             else:
-                action = "enable" if state else "disable"
-                _LOGGER.error(f"Failed to {action} discharge time control")
+                _LOGGER.error("No pending store found for discharge time control")
         except Exception as ex:
-            action = "enable" if state else "disable"
-            _LOGGER.error(f"Error trying to {action} discharge time control: {ex}")
+            _LOGGER.error(f"Error staging discharge time control: {ex}")
 
 
 class ByteWattGridChargeSwitch(ByteWattSwitchEntity):
@@ -155,21 +160,15 @@ class ByteWattGridChargeSwitch(ByteWattSwitchEntity):
         )
 
     async def _async_set_state(self, state: bool) -> None:
-        """Set the grid charging state."""
+        """Stage the grid charging state in pending store."""
         try:
-            client = self.hass.data[DOMAIN][self._config_entry.entry_id]["client"]
-            
-            # Use the client's update method with the grid_charging parameter
-            success = await client.update_battery_settings(grid_charging=state)
-            
-            if success:
-                action = "enabled" if state else "disabled"
-                _LOGGER.info(f"Successfully {action} grid charging")
-                # Trigger coordinator refresh to update other entities
-                await self.coordinator.async_request_refresh()
+            from .pending import get_pending
+            pending = get_pending(self.hass, self._config_entry.entry_id)
+            if pending is not None:
+                pending.set_battery(grid_charging=state)
+                _LOGGER.debug("Staged grid_charging=%s (pending submit)", state)
+                self.async_write_ha_state()
             else:
-                action = "enable" if state else "disable"
-                _LOGGER.error(f"Failed to {action} grid charging")
+                _LOGGER.error("No pending store found for grid charging")
         except Exception as ex:
-            action = "enable" if state else "disable"
-            _LOGGER.error(f"Error trying to {action} grid charging: {ex}")
+            _LOGGER.error(f"Error staging grid charging: {ex}")

--- a/custom_components/bytewatt/time.py
+++ b/custom_components/bytewatt/time.py
@@ -24,6 +24,9 @@ async def async_setup_entry(
     """Set up Byte-Watt time entities from a config entry."""
     coordinator = hass.data[DOMAIN][config_entry.entry_id]["coordinator"]
 
+    from .grid_feedin import async_setup_time_entry as _feedin_setup
+    await _feedin_setup(hass, config_entry, async_add_entities)
+
     entities = [
         ByteWattChargeStartTime(coordinator, config_entry),
         ByteWattChargeEndTime(coordinator, config_entry),
@@ -99,8 +102,14 @@ class ByteWattChargeStartTime(ByteWattTimeEntity):
 
     @property
     def native_value(self) -> Optional[time]:
-        """Return the current charge start time."""
+        """Return pending value if staged, else current API cache value."""
         try:
+            from .pending import get_pending
+            pending = get_pending(self.hass, self._config_entry.entry_id)
+            if pending is not None:
+                val = pending.get_battery("charge_start_time")
+                if val is not None:
+                    return self._parse_time_string(val)
             client = self.hass.data[DOMAIN][self._config_entry.entry_id]["client"]
             if hasattr(client.api_client, "_settings_cache") and client.api_client._settings_cache:
                 settings = client.api_client._settings_cache
@@ -111,18 +120,18 @@ class ByteWattChargeStartTime(ByteWattTimeEntity):
         return None
 
     async def async_set_value(self, value: time) -> None:
-        """Set the charge start time."""
+        """Stage charge start time in pending store."""
         try:
-            client = self.hass.data[DOMAIN][self._config_entry.entry_id]["client"]
-            time_str = self._format_time_for_api(value)
-            success = await client.update_battery_settings(charge_start_time=time_str)
-            if success:
-                _LOGGER.info(f"Successfully updated charge start time to {time_str}")
-                await self.coordinator.async_request_refresh()
+            from .pending import get_pending
+            pending = get_pending(self.hass, self._config_entry.entry_id)
+            if pending is not None:
+                pending.set_battery(charge_start_time=self._format_time_for_api(value))
+                _LOGGER.debug("Staged charge_start_time=%s (pending submit)", value)
+                self.async_write_ha_state()
             else:
-                _LOGGER.error(f"Failed to update charge start time to {time_str}")
+                _LOGGER.error("No pending store found for charge start time")
         except Exception as ex:
-            _LOGGER.error(f"Error setting charge start time to {value}: {ex}")
+            _LOGGER.error(f"Error staging charge start time to {value}: {ex}")
 
 
 class ByteWattChargeEndTime(ByteWattTimeEntity):
@@ -143,8 +152,14 @@ class ByteWattChargeEndTime(ByteWattTimeEntity):
 
     @property
     def native_value(self) -> Optional[time]:
-        """Return the current charge end time."""
+        """Return pending value if staged, else current API cache value."""
         try:
+            from .pending import get_pending
+            pending = get_pending(self.hass, self._config_entry.entry_id)
+            if pending is not None:
+                val = pending.get_battery("charge_end_time")
+                if val is not None:
+                    return self._parse_time_string(val)
             client = self.hass.data[DOMAIN][self._config_entry.entry_id]["client"]
             if hasattr(client.api_client, "_settings_cache") and client.api_client._settings_cache:
                 settings = client.api_client._settings_cache
@@ -155,18 +170,18 @@ class ByteWattChargeEndTime(ByteWattTimeEntity):
         return None
 
     async def async_set_value(self, value: time) -> None:
-        """Set the charge end time."""
+        """Stage charge end time in pending store."""
         try:
-            client = self.hass.data[DOMAIN][self._config_entry.entry_id]["client"]
-            time_str = self._format_time_for_api(value)
-            success = await client.update_battery_settings(charge_end_time=time_str)
-            if success:
-                _LOGGER.info(f"Successfully updated charge end time to {time_str}")
-                await self.coordinator.async_request_refresh()
+            from .pending import get_pending
+            pending = get_pending(self.hass, self._config_entry.entry_id)
+            if pending is not None:
+                pending.set_battery(charge_end_time=self._format_time_for_api(value))
+                _LOGGER.debug("Staged charge_end_time=%s (pending submit)", value)
+                self.async_write_ha_state()
             else:
-                _LOGGER.error(f"Failed to update charge end time to {time_str}")
+                _LOGGER.error("No pending store found for charge end time")
         except Exception as ex:
-            _LOGGER.error(f"Error setting charge end time to {value}: {ex}")
+            _LOGGER.error(f"Error staging charge end time to {value}: {ex}")
 
 
 class ByteWattDischargeStartTime(ByteWattTimeEntity):
@@ -187,8 +202,14 @@ class ByteWattDischargeStartTime(ByteWattTimeEntity):
 
     @property
     def native_value(self) -> Optional[time]:
-        """Return the current discharge start time."""
+        """Return pending value if staged, else current API cache value."""
         try:
+            from .pending import get_pending
+            pending = get_pending(self.hass, self._config_entry.entry_id)
+            if pending is not None:
+                val = pending.get_battery("discharge_start_time")
+                if val is not None:
+                    return self._parse_time_string(val)
             client = self.hass.data[DOMAIN][self._config_entry.entry_id]["client"]
             if hasattr(client.api_client, "_settings_cache") and client.api_client._settings_cache:
                 settings = client.api_client._settings_cache
@@ -199,18 +220,18 @@ class ByteWattDischargeStartTime(ByteWattTimeEntity):
         return None
 
     async def async_set_value(self, value: time) -> None:
-        """Set the discharge start time."""
+        """Stage discharge start time in pending store."""
         try:
-            client = self.hass.data[DOMAIN][self._config_entry.entry_id]["client"]
-            time_str = self._format_time_for_api(value)
-            success = await client.update_battery_settings(discharge_start_time=time_str)
-            if success:
-                _LOGGER.info(f"Successfully updated discharge start time to {time_str}")
-                await self.coordinator.async_request_refresh()
+            from .pending import get_pending
+            pending = get_pending(self.hass, self._config_entry.entry_id)
+            if pending is not None:
+                pending.set_battery(discharge_start_time=self._format_time_for_api(value))
+                _LOGGER.debug("Staged discharge_start_time=%s (pending submit)", value)
+                self.async_write_ha_state()
             else:
-                _LOGGER.error(f"Failed to update discharge start time to {time_str}")
+                _LOGGER.error("No pending store found for discharge start time")
         except Exception as ex:
-            _LOGGER.error(f"Error setting discharge start time to {value}: {ex}")
+            _LOGGER.error(f"Error staging discharge start time to {value}: {ex}")
 
 
 class ByteWattDischargeEndTime(ByteWattTimeEntity):
@@ -231,8 +252,14 @@ class ByteWattDischargeEndTime(ByteWattTimeEntity):
 
     @property
     def native_value(self) -> Optional[time]:
-        """Return the current discharge end time."""
+        """Return pending value if staged, else current API cache value."""
         try:
+            from .pending import get_pending
+            pending = get_pending(self.hass, self._config_entry.entry_id)
+            if pending is not None:
+                val = pending.get_battery("discharge_end_time")
+                if val is not None:
+                    return self._parse_time_string(val)
             client = self.hass.data[DOMAIN][self._config_entry.entry_id]["client"]
             if hasattr(client.api_client, "_settings_cache") and client.api_client._settings_cache:
                 settings = client.api_client._settings_cache
@@ -243,15 +270,15 @@ class ByteWattDischargeEndTime(ByteWattTimeEntity):
         return None
 
     async def async_set_value(self, value: time) -> None:
-        """Set the discharge end time."""
+        """Stage discharge end time in pending store."""
         try:
-            client = self.hass.data[DOMAIN][self._config_entry.entry_id]["client"]
-            time_str = self._format_time_for_api(value)
-            success = await client.update_battery_settings(discharge_end_time=time_str)
-            if success:
-                _LOGGER.info(f"Successfully updated discharge end time to {time_str}")
-                await self.coordinator.async_request_refresh()
+            from .pending import get_pending
+            pending = get_pending(self.hass, self._config_entry.entry_id)
+            if pending is not None:
+                pending.set_battery(discharge_end_time=self._format_time_for_api(value))
+                _LOGGER.debug("Staged discharge_end_time=%s (pending submit)", value)
+                self.async_write_ha_state()
             else:
-                _LOGGER.error(f"Failed to update discharge end time to {time_str}")
+                _LOGGER.error("No pending store found for discharge end time")
         except Exception as ex:
-            _LOGGER.error(f"Error setting discharge end time to {value}: {ex}")
+            _LOGGER.error(f"Error staging discharge end time to {value}: {ex}")

--- a/custom_components/bytewatt/translations/en.json
+++ b/custom_components/bytewatt/translations/en.json
@@ -2,28 +2,26 @@
   "config": {
     "step": {
       "user": {
-        "title": "Byte-Watt Battery Monitor",
-        "description": "Set up your Byte-Watt battery monitoring system",
+        "title": "Byte-Watt Login",
         "data": {
           "username": "Username",
           "password": "Password",
           "scan_interval": "Scan Interval (seconds)"
         }
+      },
+      "select_inverter": {
+        "title": "Select Host Inverter",
+        "description": "Multiple inverters were found on your account. Please select the Host inverter to use for Grid Feed-in control.",
+        "data": {
+          "host_system_id": "Multiple inverters found — please select the Host inverter for controls"
+        }
       }
     },
     "error": {
-      "auth": "Authentication failed. Please check your credentials."
-    }
-  },
-  "options": {
-    "step": {
-      "init": {
-        "title": "Byte-Watt Options",
-        "description": "Configure the Byte-Watt integration",
-        "data": {
-          "scan_interval": "Scan Interval (seconds)"
-        }
-      }
+      "auth": "Invalid credentials. Please check your username and password."
+    },
+    "abort": {
+      "already_configured": "This Byte-Watt account is already configured."
     }
   }
 }


### PR DESCRIPTION
<html>
<body>
<h2>Summary</h2>
<p>Two related changes in one PR:</p>
<ol>
<li>
<p><strong>Fix battery settings to use the correct API endpoint</strong> — the integration was reading and writing charge/discharge schedules via <code>getChargeConfigInfo</code>/<code>updateChargeConfigInfo</code>, which the Byte-Watt platform no longer uses. The website now uses <code>getCycleStrategy</code>/<code>setCycleStrategy</code> which has a richer per-slot structure. This caused incorrect values showing in HA for charge/discharge times, minimum SOC, and charge cap.</p>
</li>
<li>
<p><strong>Add Grid Feed-in Control entities</strong> — the Byte-Watt portal recently added a Grid Feed-in Control section. This PR surfaces the key controls in HA so they can be managed and automated without visiting the portal.</p>
</li>
</ol>
<hr>
<h2>Changes</h2>
<h3>Bug fix: Migrate battery settings to <code>getCycleStrategy</code> / <code>setCycleStrategy</code></h3>
<p><strong><code>models.py</code></strong></p>
<ul>
<li>Replaces <code>BatterySettings</code> with a new <code>CycleStrategy</code> dataclass that maps to the real API response structure, including <code>ChargeSlot</code> and <code>DischargeSlot</code> lists with <code>beginTime</code>, <code>endTime</code>, <code>chargeLimit</code>, and <code>chargePower</code> per slot</li>
<li>Adds <code>BatterySettings = CycleStrategy</code> alias so any existing code importing the old name continues to work</li>
<li>Exposes compatibility property aliases (<code>time_chaf1a</code>, <code>time_dise1a</code>, <code>bat_use_cap</code>, <code>bat_high_cap</code>, <code>grid_charge</code>, <code>ctr_dis</code> etc.) so entity code needs no changes</li>
<li>Adds <code>GridFeedInSlot</code> and <code>GridFeedInSettings</code> dataclasses for the feed-in feature</li>
</ul>
<p><strong><code>api/settings.py</code></strong></p>
<ul>
<li>Rewrites <code>BatterySettingsAPI</code> to use <code>getCycleStrategy?id=</code> (GET) and <code>setCycleStrategy</code> (PUT)</li>
<li>Keeps identical public method signatures (<code>fetch_current_settings</code>, <code>update_battery_settings</code>, <code>set_battery_settings</code>) so <code>neovolt_client.py</code> needs no changes</li>
<li>Adds <code>GridFeedInSettingsAPI</code> using confirmed endpoints <code>getFeedStrategyList</code> (GET) and <code>saveFeedStrategy</code> (POST), with field names verified from a live HAR capture</li>
</ul>
<h3>New feature: Grid Feed-in Control</h3>
<p><strong><code>grid_feedin.py</code></strong> <em>(new file)</em></p>
<ul>
<li><code>ByteWattGridFeedInSwitch</code> — enable/disable the Grid Feed-in Function (<code>batteryEn</code>)</li>
<li><code>ByteWattGridFeedInCutoffSOC</code> — discharging cutoff SOC % (<code>batteryFeedCutoffSoc</code>)</li>
<li><code>ByteWattGridFeedInSlotStartTime</code> — Time Period 1 start time</li>
<li><code>ByteWattGridFeedInSlotEndTime</code> — Time Period 1 end time</li>
<li><code>ByteWattGridFeedInSlotPower</code> — Time Period 1 feed-in power (W)</li>
<li>All entities write to a <code>PendingStore</code> rather than the API directly (see below)</li>
</ul>
<h3>New feature: Submit Settings button + pending store</h3>
<p><strong><code>pending.py</code></strong> <em>(new file)</em></p>
<ul>
<li><code>PendingStore</code> class holds all unsaved setting changes in memory, separated into battery and grid feed-in buckets</li>
<li><code>ByteWattSubmitButton</code> pushes all pending changes to the API in a single action, mirroring the Save button pattern used in the Byte-Watt portal</li>
<li>On failure, pending changes are discarded and all entities revert to the last known-good API cache values</li>
</ul>
<p><strong><code>button.py</code></strong> <em>(new file)</em></p>
<ul>
<li>Minimal platform shim so HA can load the <code>button</code> platform from <code>pending.py</code></li>
</ul>
<p><strong><code>switch.py</code>, <code>number.py</code>, <code>time.py</code></strong></p>
<ul>
<li>All <code>set</code> methods now stage changes in <code>PendingStore</code> instead of calling the API immediately</li>
<li>All <code>native_value</code> / <code>is_on</code> properties check the pending store first, then fall back to the API cache — so the UI reflects staged changes before submit</li>
</ul>
<p><strong><code>__init__.py</code></strong></p>
<ul>
<li>Adds <code>button</code> to <code>PLATFORMS</code></li>
<li>Creates a <code>PendingStore</code> instance per config entry in <code>hass.data</code></li>
<li>Registers three new services: <code>set_grid_feedin_enabled</code>, <code>set_grid_feedin_cutoff_soc</code>, <code>update_grid_feedin_slot</code></li>
<li>Imports new grid feed-in constants</li>
</ul>
<p><strong><code>api/neovolt_client.py</code></strong></p>
<ul>
<li>Adds <code>async_get_grid_feedin_settings()</code> and <code>async_update_grid_feedin_settings()</code> using a <code>_grid_feedin_cache</code> attribute</li>
</ul>
<p><strong><code>bytewatt_client.py</code></strong></p>
<ul>
<li>Exposes <code>get_grid_feedin_settings()</code> and <code>update_grid_feedin_settings()</code> as public methods</li>
</ul>
<p><strong><code>coordinator.py</code></strong></p>
<ul>
<li>Fetches grid feed-in settings on each poll cycle alongside the existing battery settings fetch</li>
</ul>
<p><strong><code>const.py</code></strong></p>
<ul>
<li>Adds grid feed-in service names and attribute constants</li>
</ul>
<p><strong><code>services.yaml</code></strong></p>
<ul>
<li>Adds <code>set_grid_feedin_enabled</code>, <code>set_grid_feedin_cutoff_soc</code>, <code>update_grid_feedin_slot</code> service definitions</li>
<li>Removes duplicate service keys that caused YAML warnings on startup</li>
</ul>
<hr>
<h2>Why the submit button approach</h2>
<p>The Byte-Watt API is sensitive to rapid sequential writes and would intermittently fail when HA pushed each setting change immediately as the user adjusted sliders or time pickers. Staging all changes locally and submitting once mirrors the UX of the portal itself (which also has a single Save button) and eliminates these failures.</p>
<hr>
<h2>API endpoints verified</h2>
<p>All endpoints and field names were confirmed against a live HAR capture from the Byte-Watt portal:</p>

Operation | Method | Endpoint
-- | -- | --
Get charge/discharge schedule | GET | api/iterate/sysSet/getCycleStrategy?id=
Save charge/discharge schedule | PUT | api/iterate/sysSet/setCycleStrategy
Get grid feed-in settings | GET | api/iterate/sysSet/getFeedStrategyList?id=<systemId>
Save grid feed-in settings | POST | api/iterate/sysSet/saveFeedStrategy
Get system ID | GET | api/stable/home/getCustomMenuEssList?inverterMode=0


<hr>
<h2>Validation</h2>
<ul>
<li>Tested on a live Byte-Watt / Neovolt system running Home Assistant</li>
<li>API endpoints and field names confirmed via HAR capture from the portal</li>
<li>All existing entities continue to function correctly after the <code>CycleStrategy</code> migration</li>
<li>Submit button correctly reverts entity state on API failure</li>
</ul></body></html><!--EndFragment-->
</body>
</html>