### PR TITLE
Handle missing charge slot when submitting battery settings

### DIFF
--- a/custom_components/bytewatt/const.py
+++ b/custom_components/bytewatt/const.py
@@ -113,6 +113,10 @@ FEEDIN_MAX_SLOTS = 6
 # and entity slider max.
 FEEDIN_MAX_POWER_W = 20000
 
+# Default charge power (watts) applied when auto-creating a charge slot that
+# the inverter did not return. Matches the charge-power slider max in number.py.
+DEFAULT_CHARGE_POWER_W = 10000
+
 
 def signal_pending_changed(entry_id: str) -> str:
     """Dispatcher signal name for pending-store changes on a given entry."""

--- a/custom_components/bytewatt/settings_manager.py
+++ b/custom_components/bytewatt/settings_manager.py
@@ -40,8 +40,8 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.util import dt as dt_util
 
 from .api.settings import BatterySettingsAPI, GridFeedInSettingsAPI
-from .const import signal_pending_changed
-from .models import CycleStrategy, GridFeedInSettings, GridFeedInSlot
+from .const import DEFAULT_CHARGE_POWER_W, signal_pending_changed
+from .models import ChargeSlot, CycleStrategy, GridFeedInSettings, GridFeedInSlot
 from .utilities.time_utils import sanitize_time_format
 
 _LOGGER = logging.getLogger(__name__)
@@ -691,9 +691,7 @@ class SettingsManager:
             merged.bat_use_cap = float(pending["minimum_soc"])
         if "charge_cap" in pending:
             if not merged.charge_slots:
-                raise SettingsValidationError(
-                    "Cannot set charge_cap: no charge slot defined on the inverter"
-                )
+                merged.charge_slots.append(ChargeSlot(charge_power=DEFAULT_CHARGE_POWER_W))
             merged.charge_slots[0].charge_limit = float(pending["charge_cap"])
         if "grid_charging" in pending:
             merged.grid_charge_cycle = 1 if pending["grid_charging"] else 0
@@ -709,14 +707,17 @@ class SettingsManager:
             if field_name in pending:
                 slots = getattr(merged, slot_list_attr)
                 if not slots:
-                    raise SettingsValidationError(
-                        f"Cannot set {field_name}: no slot defined on the inverter"
-                    )
+                    if slot_list_attr == "charge_slots":
+                        slots.append(ChargeSlot(charge_power=DEFAULT_CHARGE_POWER_W))
+                    else:
+                        raise SettingsValidationError(
+                            f"Cannot set {field_name}: no slot defined on the inverter"
+                        )
                 setattr(slots[0], slot_attr, pending[field_name])
 
         if "charge_power" in pending:
             if not merged.charge_slots:
-                raise SettingsValidationError("Cannot set charge_power: no charge slot")
+                merged.charge_slots.append(ChargeSlot(charge_power=DEFAULT_CHARGE_POWER_W))
             merged.charge_slots[0].charge_power = int(pending["charge_power"])
         if "discharge_power" in pending:
             if not merged.discharge_slots:


### PR DESCRIPTION
### Summary
When the inverter API returns an empty chargeTimeList, submitting staged battery charge settings failed with Cannot set charge_start_time: no slot defined on the inverter before a payload could be built.
This change auto-creates a default ChargeSlot when charge settings (start/end time, charge cap, charge power) are staged but no charge slot exists. Discharge slots keep the existing strict validation.

### Changes
•  Import ChargeSlot in settings_manager.py
•  _build_battery_payload: create a ChargeSlot(charge_power=10000) instead of raising when charge_slots is empty (for charge_cap, charge times, and charge_power)
•  Discharge slot handling unchanged (still raises when missing)